### PR TITLE
resolutiondate field in JIRA mapping will be now indexed - Closes #128

### DIFF
--- a/configuration/mappings/data_jbossorg_jira/jbossorg_jira_issue.json
+++ b/configuration/mappings/data_jbossorg_jira/jbossorg_jira_issue.json
@@ -10,7 +10,7 @@
             "status" : {"type" : "string", "index" : "no"},
             "sys_issue_status" : {"type" : "string", "analyzer" : "keyword", "include_in_all" : true},
             "updated" : {"type" : "date", "index" : "no"},
-            "resolutiondate" : {"type" : "date", "index" : "no"},
+            "resolutiondate" : {"type" : "date"},
             "summary" : {"type" : "string", "index" : "no"},
             "tags" : {"type" : "string", "index" : "no"},
             "fix_versions": {


### PR DESCRIPTION
To release this change the following steps need to be applied:
1. stop jira indexer:
`curl --user <login>:<password> -X POST '<DCP_URL>/v1/rest/indexer/jbossorg_jira_issue/_stop'`
2. delete mapping:
`curl --user <login>:<password> -XDELETE '<ES_API_URL>/data_jbossorg_jira/jbossorg_jira_issue'`
3. push mapping:
`sh init_mapping.sh data_jbossorg_jira/jbossorg_jira_issue.json <ES_API_URL> <LOGIN> <PASSWORD>`
4. start river:
`curl --user <login>:<password> -X POST '<DCP_URL>/v1/rest/indexer/jbossorg_jira_issue/_restart'`
5. force reindex:
`curl --user <login>:<password> -X POST '<DCP_URL>/v1/rest/indexer/jbossorg_jira_issue/_force_reindex'`
