### PR TITLE
Change roles in logged in user immediatelly when roles are modified. fixes #147

### DIFF
--- a/.openshift/config/standalone.xml
+++ b/.openshift/config/standalone.xml
@@ -233,6 +233,11 @@
 			<iiop enable-by-default="false" use-qualified-name="false" />
 		</subsystem>
 		<subsystem xmlns="urn:jboss:domain:infinispan:1.4">
+			<cache-container name="searchisko">
+				<transport lock-timeout="60000"/>
+				<replicated-cache name="searchisko-user-roles" mode="SYNC" batching="true">
+				</replicated-cache>
+			</cache-container>
 			<cache-container name="cluster" aliases="ha-partition"
 				default-cache="default">
 				<transport lock-timeout="60000" />

--- a/api/pom.xml
+++ b/api/pom.xml
@@ -147,6 +147,11 @@
 		</dependency>
 
 		<dependency>
+			<groupId>commons-collections</groupId>
+			<artifactId>commons-collections</artifactId>
+		</dependency>
+
+		<dependency>
 			<groupId>org.elasticsearch</groupId>
 			<artifactId>elasticsearch</artifactId>
 		</dependency>
@@ -187,6 +192,13 @@
 		<dependency>
 			<groupId>org.picketbox</groupId>
 			<artifactId>picketbox</artifactId>
+			<scope>provided</scope>
+		</dependency>
+
+		<!-- Needed by using Infinispan CacheManager -->
+		<dependency>
+			<groupId>org.infinispan</groupId>
+			<artifactId>infinispan-core</artifactId>
 			<scope>provided</scope>
 		</dependency>
 

--- a/api/src/main/java/org/searchisko/api/events/RolesUpdatedEvent.java
+++ b/api/src/main/java/org/searchisko/api/events/RolesUpdatedEvent.java
@@ -1,0 +1,45 @@
+/*
+ * JBoss, Home of Professional Open Source
+ * Copyright 2014 Red Hat Inc. and/or its affiliates and other contributors
+ * as indicated by the @authors tag. All rights reserved.
+ */
+
+package org.searchisko.api.events;
+
+import java.util.Map;
+
+import org.searchisko.api.security.AuthenticatedUserType;
+
+/**
+ * CDI Event to notify system that roles has changed for given authenticated entity.
+ *
+ * @author Libor Krzyzanek
+ * @see org.searchisko.api.security.util.ActualRolesService
+ */
+public class RolesUpdatedEvent {
+
+	private AuthenticatedUserType authenticatedUserType;
+
+	private Map<String, Object> entity;
+
+	public RolesUpdatedEvent(AuthenticatedUserType authenticatedUserType, Map<String, Object> entity) {
+		this.authenticatedUserType = authenticatedUserType;
+		this.entity = entity;
+	}
+
+	public Map<String, Object> getEntity() {
+		return entity;
+	}
+
+	public AuthenticatedUserType getAuthenticatedUserType() {
+		return authenticatedUserType;
+	}
+
+	@Override
+	public String toString() {
+		return "RolesUpdatedEvent{" +
+				"authenticatedUserType=" + authenticatedUserType +
+				", entity=" + entity +
+				'}';
+	}
+}

--- a/api/src/main/java/org/searchisko/api/security/jaas/ContributorPrincipal.java
+++ b/api/src/main/java/org/searchisko/api/security/jaas/ContributorPrincipal.java
@@ -1,5 +1,8 @@
 package org.searchisko.api.security.jaas;
 
+import java.util.HashSet;
+import java.util.Set;
+
 import org.jasig.cas.client.validation.Assertion;
 
 /**
@@ -8,7 +11,9 @@ import org.jasig.cas.client.validation.Assertion;
  * @author Libor Krzyzanek
  * @see org.jasig.cas.client.jaas.AssertionPrincipal
  */
-public class ContributorPrincipal extends org.jasig.cas.client.jaas.AssertionPrincipal {
+public class ContributorPrincipal extends org.jasig.cas.client.jaas.AssertionPrincipal implements PrincipalWithRoles {
+
+	protected Set<String> roles;
 
 	/**
 	 * Use only for test purposes!
@@ -27,13 +32,27 @@ public class ContributorPrincipal extends org.jasig.cas.client.jaas.AssertionPri
 	 */
 	public ContributorPrincipal(final String name, final Assertion assertion) {
 		super(name, assertion);
+		this.roles = new HashSet<>();
 	}
+
+	@Override
+	public Set<String> getRoles() {
+		return roles;
+	}
+
+	@Override
+	public void setRoles(Set<String> roles) {
+		this.roles = roles;
+	}
+
+
 
 	@Override
 	public String toString() {
 		return "ContributorPrincipal{" +
 				"name='" + getName() + '\'' +
 				",assertion='" + getAssertion() + '\'' +
+				",roles='" + roles + '\'' +
 				'}';
 	}
 }

--- a/api/src/main/java/org/searchisko/api/security/jaas/PrincipalWithRoles.java
+++ b/api/src/main/java/org/searchisko/api/security/jaas/PrincipalWithRoles.java
@@ -1,0 +1,23 @@
+/*
+ * JBoss, Home of Professional Open Source
+ * Copyright 2014 Red Hat Inc. and/or its affiliates and other contributors
+ * as indicated by the @authors tag. All rights reserved.
+ */
+
+package org.searchisko.api.security.jaas;
+
+import java.security.Principal;
+import java.util.Set;
+
+/**
+ * Principal with roles associated with it.
+ * JAAS doesn't provide easy way how to get list of roles for princiapl only isUserInRole
+ *
+ * @author Libor Krzyzanek
+ */
+public interface PrincipalWithRoles extends Principal {
+
+	public Set<String> getRoles();
+
+	public void setRoles(Set<String> roles);
+}

--- a/api/src/main/java/org/searchisko/api/security/jaas/ProviderPrincipal.java
+++ b/api/src/main/java/org/searchisko/api/security/jaas/ProviderPrincipal.java
@@ -1,23 +1,41 @@
 package org.searchisko.api.security.jaas;
 
-import java.security.Principal;
+import java.util.HashSet;
+import java.util.Set;
 
 /**
  * Provider principal. It's used when provider is authenticated.
  *
  * @author Libor Krzyzanek
  */
-public class ProviderPrincipal implements Principal {
+public class ProviderPrincipal implements PrincipalWithRoles {
 
 	protected String name;
 
+	protected Set<String> roles;
+
 	public ProviderPrincipal(String name) {
+		this(name, new HashSet<String>());
+	}
+
+	public ProviderPrincipal(String name, Set<String> roles) {
 		this.name = name;
+		this.roles = roles;
 	}
 
 	@Override
 	public String getName() {
 		return name;
+	}
+
+	@Override
+	public Set<String> getRoles() {
+		return roles;
+	}
+
+	@Override
+	public void setRoles(Set<String> roles) {
+		this.roles = roles;
 	}
 
 	@Override
@@ -41,6 +59,7 @@ public class ProviderPrincipal implements Principal {
 	public String toString() {
 		return "ProviderPrincipal{" +
 				"name='" + name + '\'' +
+				"roles='" + roles + '\'' +
 				'}';
 	}
 }

--- a/api/src/main/java/org/searchisko/api/security/jaas/UsersRolesForPrincipalWithRolesLoginModule.java
+++ b/api/src/main/java/org/searchisko/api/security/jaas/UsersRolesForPrincipalWithRolesLoginModule.java
@@ -1,0 +1,41 @@
+/*
+ * JBoss, Home of Professional Open Source
+ * Copyright 2014 Red Hat Inc. and/or its affiliates and other contributors
+ * as indicated by the @authors tag. All rights reserved.
+ */
+
+package org.searchisko.api.security.jaas;
+
+import java.security.Principal;
+import java.util.Enumeration;
+
+import javax.security.auth.login.LoginException;
+
+import org.jboss.security.auth.spi.UsersRolesLoginModule;
+
+/**
+ * Login module extends standard UsersRolesLoginModule and populate roles to PrincipalWithRoles object
+ *
+ * @author Libor Krzyzanek
+ * @see org.searchisko.api.security.jaas.PrincipalWithRoles
+ */
+public class UsersRolesForPrincipalWithRolesLoginModule extends UsersRolesLoginModule {
+
+	@Override
+	public boolean commit() throws LoginException {
+		boolean success = super.commit();
+
+		if (success) {
+			PrincipalWithRoles principal = (PrincipalWithRoles) getIdentity();
+
+			Enumeration<? extends Principal> roles =  getRoleSets()[0].members();
+			if (roles != null) {
+				while (roles.hasMoreElements()) {
+					principal.getRoles().add(roles.nextElement().getName());
+				}
+			}
+		}
+		return success;
+	}
+
+}

--- a/api/src/main/java/org/searchisko/api/security/util/ActualRolesRequestWrapperFilter.java
+++ b/api/src/main/java/org/searchisko/api/security/util/ActualRolesRequestWrapperFilter.java
@@ -1,0 +1,128 @@
+/*
+ * JBoss, Home of Professional Open Source
+ * Copyright 2014 Red Hat Inc. and/or its affiliates and other contributors
+ * as indicated by the @authors tag. All rights reserved.
+ */
+
+package org.searchisko.api.security.util;
+
+import java.io.IOException;
+import java.security.Principal;
+import java.util.Set;
+
+import javax.inject.Inject;
+import javax.servlet.Filter;
+import javax.servlet.FilterChain;
+import javax.servlet.FilterConfig;
+import javax.servlet.ServletException;
+import javax.servlet.ServletRequest;
+import javax.servlet.ServletResponse;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletRequestWrapper;
+
+import org.searchisko.api.security.jaas.PrincipalWithRoles;
+
+/**
+ * Request wrapper which improves {@link javax.servlet.http.HttpServletRequest#isUserInRole(String)} method by providing
+ * match against actual roles stored in cache or session by {@link org.searchisko.api.security.util.ActualRolesService}.
+ *
+ * @author Libor Krzyzanek
+ * @see org.searchisko.api.security.util.ActualRolesService#getActualRolesRemoveFromCache(java.security.Principal)
+ */
+public class ActualRolesRequestWrapperFilter implements Filter {
+
+	@Inject
+	protected ActualRolesService actualRolesService;
+
+	@Override
+	public void init(FilterConfig filterConfig) throws ServletException {
+	}
+
+	@Override
+	public void doFilter(ServletRequest request, ServletResponse response, FilterChain chain) throws IOException, ServletException {
+		RolesInSessionHttpServletRequestWrapper wrapper = new RolesInSessionHttpServletRequestWrapper((HttpServletRequest) request, actualRolesService);
+		chain.doFilter(wrapper, response);
+	}
+
+	@Override
+	public void destroy() {
+	}
+
+	/**
+	 * Wrapper improves #getUserPrincipal by updating roles in PrincipalWithRoles if any found in
+	 * {@link org.searchisko.api.security.util.ActualRolesService}
+	 * Improved #isUserInRole to check actual roles from PrincipalWithRoles
+	 *
+	 * @author Libor Krzyzanek
+	 */
+	public class RolesInSessionHttpServletRequestWrapper extends HttpServletRequestWrapper {
+
+		public static final String SESSION_ACTUAL_ROLES_KEY = "actual_roles_from_update";
+
+		private ActualRolesService actualRolesService;
+
+		public RolesInSessionHttpServletRequestWrapper(HttpServletRequest request, ActualRolesService actualRolesService) {
+			super(request);
+			this.actualRolesService = actualRolesService;
+		}
+
+		/**
+		 * Returns {@link org.searchisko.api.security.jaas.PrincipalWithRoles} with updated roles
+		 * if any found in cache/session
+		 *
+		 * @return
+		 */
+		@Override
+		public Principal getUserPrincipal() {
+			Principal principal = super.getUserPrincipal();
+			if (principal == null) {
+				return null;
+			}
+			HttpServletRequest req = (HttpServletRequest) getRequest();
+
+			Set<String> roles = getRolesFromCacheOrSession(req, principal);
+			if (roles != null) {
+				// update roles in principal
+				if (principal instanceof PrincipalWithRoles) {
+					((PrincipalWithRoles) principal).setRoles(roles);
+				}
+			}
+
+			return principal;
+		}
+
+		/**
+		 * Overrides default implementation by checking if role is PrincipalWithRoles's roles
+		 *
+		 * @param role
+		 * @return
+		 */
+		@Override
+		public boolean isUserInRole(String role) {
+			Principal principal = getUserPrincipal();
+			if (principal instanceof PrincipalWithRoles) {
+				return ((PrincipalWithRoles) principal).getRoles().contains(role);
+			}
+
+			return super.isUserInRole(role);
+		}
+
+		@SuppressWarnings("unchecked")
+		protected Set<String> getRolesFromCacheOrSession(HttpServletRequest req, Principal principal) {
+			Set<String> rolesFromCache = actualRolesService.getActualRolesRemoveFromCache(principal);
+			if (rolesFromCache != null) {
+				// keeps copy of roles in session for next requests. It's assumed that load balancer has configured sticky sessions
+				// so we're sure that next call would go to same session
+				req.getSession().setAttribute(SESSION_ACTUAL_ROLES_KEY, rolesFromCache);
+				return rolesFromCache;
+			}
+
+			Object roles = req.getSession().getAttribute(SESSION_ACTUAL_ROLES_KEY);
+			if (roles != null) {
+				return (Set<String>) roles;
+			}
+
+			return null;
+		}
+	}
+}

--- a/api/src/main/java/org/searchisko/api/security/util/ActualRolesService.java
+++ b/api/src/main/java/org/searchisko/api/security/util/ActualRolesService.java
@@ -1,0 +1,84 @@
+/*
+ * JBoss, Home of Professional Open Source
+ * Copyright 2014 Red Hat Inc. and/or its affiliates and other contributors
+ * as indicated by the @authors tag. All rights reserved.
+ */
+
+package org.searchisko.api.security.util;
+
+import java.security.Principal;
+import java.util.Map;
+import java.util.Set;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+
+import javax.annotation.PostConstruct;
+import javax.ejb.Singleton;
+import javax.enterprise.context.ApplicationScoped;
+import javax.enterprise.event.Observes;
+import javax.inject.Inject;
+import javax.inject.Named;
+
+import org.infinispan.Cache;
+import org.infinispan.manager.EmbeddedCacheManager;
+import org.searchisko.api.events.RolesUpdatedEvent;
+import org.searchisko.api.security.AuthenticatedUserType;
+import org.searchisko.api.security.Role;
+import org.searchisko.api.service.ContributorProfileService;
+import org.searchisko.api.service.ContributorService;
+
+/**
+ * Utility Service that keeps actual roles in cache.
+ * It observes {@link org.searchisko.api.events.RolesUpdatedEvent} and put updated roles into the cache.
+ *
+ * @author Libor Krzyzanek
+ */
+@Named
+@ApplicationScoped
+@Singleton
+public class ActualRolesService {
+
+	@Inject
+	protected Logger log;
+
+	@Inject
+	protected EmbeddedCacheManager container;
+
+	public static final String CACHE_NAME = "searchisko-user-roles";
+
+	protected Cache<Object, Set<String>> actualRoles;
+
+	@PostConstruct
+	public void init() {
+		actualRoles = container.getCache(CACHE_NAME);
+	}
+
+	public void rolesUpdatedEventHandler(@Observes RolesUpdatedEvent event) {
+		log.log(Level.FINE, "event: {0}", event);
+
+		if (AuthenticatedUserType.CONTRIBUTOR.equals(event.getAuthenticatedUserType())) {
+			Map<String, Object> entity = event.getEntity();
+			String username = ContributorService.getContributorTypeSpecificCodeFirst(entity, ContributorProfileService.FIELD_TSC_JBOSSORG_USERNAME);
+
+			String key = getCacheKey(AuthenticatedUserType.CONTRIBUTOR, username);
+			Set<String> roles = ContributorService.extractRoles(entity);
+			roles.add(Role.CONTRIBUTOR);
+			actualRoles.put(key, roles);
+		}
+	}
+
+	public static String getCacheKey(AuthenticatedUserType authenticatedUserType, String username) {
+		return authenticatedUserType.name() + "-" + username;
+	}
+
+	@SuppressWarnings("unchecked")
+	public Set<String> getActualRolesRemoveFromCache(Principal principal) {
+		String key = getCacheKey(AuthenticatedUserType.CONTRIBUTOR, principal.getName());
+
+		if (!actualRoles.containsKey(key)) {
+			return null;
+		}
+		return actualRoles.remove(key);
+	}
+
+}

--- a/api/src/main/java/org/searchisko/api/service/AuthenticationUtilService.java
+++ b/api/src/main/java/org/searchisko/api/service/AuthenticationUtilService.java
@@ -7,6 +7,7 @@ package org.searchisko.api.service;
 
 import java.security.Principal;
 import java.util.Collection;
+import java.util.Set;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
@@ -21,6 +22,7 @@ import org.searchisko.api.rest.exception.NotAuthorizedException;
 import org.searchisko.api.security.AuthenticatedUserType;
 import org.searchisko.api.security.Role;
 import org.searchisko.api.security.jaas.ContributorPrincipal;
+import org.searchisko.api.security.jaas.PrincipalWithRoles;
 import org.searchisko.api.util.SearchUtils;
 
 /**
@@ -242,6 +244,22 @@ public class AuthenticationUtilService {
 		} else {
 			return null;
 		}
+	}
+
+	/**
+	 * Get user roles for actually authenticated user.
+	 *
+	 * @return null if user is not authenticated or principal is not instance of {@link org.searchisko.api.security.jaas.PrincipalWithRoles}
+	 */
+	public Set<String> getUserRoles() {
+		Principal principal = httpRequest.getUserPrincipal();
+		if (httpRequest.getUserPrincipal() == null) {
+			return null;
+		}
+		if (principal instanceof PrincipalWithRoles) {
+			return ((PrincipalWithRoles)principal).getRoles();
+		}
+		return null;
 	}
 
 	/**

--- a/api/src/main/java/org/searchisko/api/util/Resources.java
+++ b/api/src/main/java/org/searchisko/api/util/Resources.java
@@ -10,6 +10,7 @@ import java.io.InputStreamReader;
 import java.io.StringWriter;
 import java.util.logging.Logger;
 
+import javax.annotation.Resource;
 import javax.ejb.Singleton;
 import javax.enterprise.context.ContextNotActiveException;
 import javax.enterprise.context.RequestScoped;
@@ -19,6 +20,8 @@ import javax.faces.context.FacesContext;
 import javax.inject.Named;
 import javax.persistence.EntityManager;
 import javax.persistence.PersistenceContext;
+
+import org.infinispan.manager.EmbeddedCacheManager;
 
 /**
  * This class uses CDI to alias Java EE resources, such as the persistence context, to CDI beans
@@ -63,6 +66,11 @@ public class Resources {
 		}
 		return ctx;
 	}
+
+	@SuppressWarnings("unused")
+	@Produces
+	@Resource(lookup="java:jboss/infinispan/container/searchisko")
+	private static EmbeddedCacheManager container;
 
 	/**
 	 * Read file from classpath into String. UTF-8 encoding expected.

--- a/api/src/main/webapp/WEB-INF/jboss-deployment-structure.xml
+++ b/api/src/main/webapp/WEB-INF/jboss-deployment-structure.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<jboss-deployment-structure>
+	<deployment>
+		<dependencies>
+			<module name="org.infinispan" />
+		</dependencies>
+	</deployment>
+</jboss-deployment-structure>

--- a/api/src/main/webapp/WEB-INF/web.xml
+++ b/api/src/main/webapp/WEB-INF/web.xml
@@ -43,6 +43,12 @@
 		<filter-class>org.searchisko.api.filter.BasicAuthenticationFilter</filter-class>
 	</filter>
 
+	<!-- ###### Actual Roles request wrapper (#147) ###### -->
+	<filter>
+		<filter-name>Actual Roles Request Wrapper</filter-name>
+		<filter-class>org.searchisko.api.security.util.ActualRolesRequestWrapperFilter</filter-class>
+	</filter>
+
 	<!-- ###### CAS SSO begin ###### -->
 
 	<!-- SSO calls this to drop HTTP session if user is logged out -->
@@ -83,7 +89,7 @@
 	</filter>
 	<!-- ###### CAS SSO end ###### -->
 
-<!-- ###### ES proxy handling filter ###### -->
+	<!-- ###### ES proxy handling filter ###### -->
 	<filter>
 		<filter-name>Search ES Filter</filter-name>
 		<filter-class>org.searchisko.api.filter.ESProxyFilter</filter-class>
@@ -103,6 +109,12 @@
 		<filter-name>Basic Authentication Consumer Filter</filter-name>
 		<url-pattern>/*</url-pattern>
 	</filter-mapping>
+
+	<filter-mapping>
+		<filter-name>Actual Roles Request Wrapper</filter-name>
+		<url-pattern>/*</url-pattern>
+	</filter-mapping>
+
 	<filter-mapping>
 		<filter-name>CORS Filter</filter-name>
 		<url-pattern>/v1/rest/*</url-pattern>
@@ -121,12 +133,12 @@
 		<url-pattern>/v1/rest/auth/status</url-pattern>
 	</filter-mapping>
 	<filter-mapping>
-	  <filter-name>Search ES Filter</filter-name>
-	  <url-pattern>/v1/rest/sys/es/search/*</url-pattern>
+		<filter-name>Search ES Filter</filter-name>
+		<url-pattern>/v1/rest/sys/es/search/*</url-pattern>
 	</filter-mapping>
-  <filter-mapping>
-	  <filter-name>Stats ES Filter</filter-name>
-	  <url-pattern>/v1/rest/sys/es/stats/*</url-pattern>
+	<filter-mapping>
+		<filter-name>Stats ES Filter</filter-name>
+		<url-pattern>/v1/rest/sys/es/stats/*</url-pattern>
 	</filter-mapping>
 
 	<listener>

--- a/api/src/test/java/org/searchisko/api/service/ContributorServiceTest.java
+++ b/api/src/test/java/org/searchisko/api/service/ContributorServiceTest.java
@@ -580,6 +580,33 @@ public class ContributorServiceTest extends ESRealClientTestBase {
 	}
 
 	@Test
+	public void isRolesChanged() {
+		ContributorService tested = new ContributorService();
+		tested.entityService = Mockito.mock(EntityService.class);
+
+		Map<String, Object> oldEntity = new HashMap<>();
+		List<String> oldRoles = new ArrayList<>();
+		oldEntity.put(ContributorService.FIELD_ROLES, oldRoles);
+
+		oldRoles.add("admin");
+		oldRoles.add("contributor");
+		Mockito.when(tested.entityService.get(Mockito.anyString())).thenReturn(oldEntity);
+
+
+		Map<String, Object> newEntity = new HashMap<>();
+		List<String> newRoles = new ArrayList<>();
+		newEntity.put(ContributorService.FIELD_ROLES, newRoles);
+
+		newRoles.add("admin");
+		newRoles.add("contributor");
+		Assert.assertFalse(tested.isRolesChanged("", newEntity));
+
+		newRoles.remove("admin");
+		Assert.assertTrue(tested.isRolesChanged("", newEntity));
+
+	}
+
+	@Test
 	public void delete() throws InterruptedException {
 		Client client = prepareESClientForUnitTest();
 		ContributorService tested = getTested(client);

--- a/documentation/development.md
+++ b/documentation/development.md
@@ -84,9 +84,34 @@ Just copy this security domain definition into `<subsystem xmlns="urn:jboss:doma
 
 See how is Openshift configured in [Configuration](/.openshift/conf/standalone.xml) for instance.
 
+### Cache
+Searchisko needs configured container cache for actual roles distribution which happens when contributor's roles are changed.
+
+Standalone configuration:
+Just copy this cache configuration into `<subsystem xmlns="urn:jboss:domain:infinispan:1.5">` section of `standalone.xml`:
+
+	<cache-container name="searchisko">
+		<local-cache name="searchisko-user-roles">
+			<!-- Expiration - 30 mins - should be same as session expiration -->
+			<expiration lifespan="1800000"/>
+		</local-cache>
+	</cache-container>
+
+
+Clustered configuration:
+TODO: Test cluster deployment 
+Edit `domain/configuration/domain.xml` and add a this cache container configuration to the `full-ha` profile:
+
+    <cache-container name="searchisko">
+        <transport lock-timeout="60000"/>
+        <replicated-cache name="searchisko-user-roles" mode="SYNC" batching="true">
+        </replicated-cache>
+    </cache-container>
+
+[More info](https://docs.jboss.org/author/display/ISPN/Clustering+modes#Clusteringmodes-ReplicatedMode)
 
 ### Audit Log
-Audit log is handled via Java Logging facitility and thus can be tuned in AS logging configuration.
+Audit log is handled via Java Logging facility and thus can be tuned in AS logging configuration.
 In JBoss AS it's wise to not mix audit logs with system logging and it can be achieved by logging configuration like this
 (all within `<subsystem xmlns="urn:jboss:domain:logging:1.3">` subsystem):
 

--- a/ftest/README.md
+++ b/ftest/README.md
@@ -27,7 +27,7 @@ It's needed to add security domain `SearchiskoSecurityDomainFTEST` into the `$JB
 					<authentication>
 						<login-module code="org.searchisko.api.security.jaas.ProviderLoginModule" flag="sufficient">
 						</login-module>
-						<login-module code="org.jboss.security.auth.spi.UsersRolesLoginModule" flag="sufficient">
+						<login-module code="org.searchisko.api.security.jaas.UsersRolesForPrincipalWithRolesLoginModule" flag="sufficient">
 							<module-option name="principalClass" value="org.searchisko.api.security.jaas.ContributorPrincipal" />
 							<module-option name="usersProperties" value="searchisko-ftest-users.properties" /> 
 							<module-option name="rolesProperties" value="searchisko-ftest-roles.properties" />
@@ -40,7 +40,14 @@ It's needed to add security domain `SearchiskoSecurityDomainFTEST` into the `$JB
 
 Note: Security domain name is intentionally different because functional tests uses HTTP Basic authentication to authenticate contributors.
 
-See [JBoss EAP 6.3 standalone.xml example](§) how it can looks like
+Copy this cache configuration into `<subsystem xmlns="urn:jboss:domain:infinispan:1.5">` section of `standalone.xml`:
+
+	<cache-container name="searchisko">
+		<local-cache name="searchisko-user-roles" />
+	</cache-container>
+
+See [JBoss EAP 6.3 standalone.xml example](src/conf/jboss-eap-6.3-standalone.xml) how it can looks like
+
 
 Running tests
 -------------

--- a/ftest/src/conf/jboss-eap-6.3-standalone.xml
+++ b/ftest/src/conf/jboss-eap-6.3-standalone.xml
@@ -205,6 +205,9 @@
             <default-missing-method-permissions-deny-access value="true"/>
         </subsystem>
         <subsystem xmlns="urn:jboss:domain:infinispan:1.5">
+			<cache-container name="searchisko">
+				<local-cache name="searchisko-user-roles" />
+			</cache-container>
             <cache-container name="web" aliases="standard-session-cache" default-cache="local-web" module="org.jboss.as.clustering.web.infinispan">
                 <local-cache name="local-web" batching="true">
                     <file-store passivation="false" purge="false"/>
@@ -276,7 +279,7 @@
                 <security-domain name="SearchiskoSecurityDomainFTEST">
                     <authentication>
                         <login-module code="org.searchisko.api.security.jaas.ProviderLoginModule" flag="sufficient"/>
-                        <login-module code="org.jboss.security.auth.spi.UsersRolesLoginModule" flag="sufficient">
+                        <login-module code="org.searchisko.api.security.jaas.UsersRolesForPrincipalWithRolesLoginModule" flag="sufficient">
                             <module-option name="principalClass" value="org.searchisko.api.security.jaas.ContributorPrincipal"/>
                             <module-option name="usersProperties" value="searchisko-ftest-users.properties"/>
                             <module-option name="rolesProperties" value="searchisko-ftest-roles.properties"/>

--- a/ftest/src/test/java/org/searchisko/ftest/DeploymentHelpers.java
+++ b/ftest/src/test/java/org/searchisko/ftest/DeploymentHelpers.java
@@ -155,7 +155,8 @@ public class DeploymentHelpers {
 				.addAsWebInfResource(new StringAsset("<jboss-web><security-domain>" + SECURITY_DOMAIN
 						+ "</security-domain></jboss-web>"), "jboss-web.xml")
 				.addAsWebInfResource("webapp/WEB-INF/test-searchisko-ds.xml", "searchisko-ds.xml")
-				.addAsWebInfResource(new File(projectRootPath + "/api/src/main/webapp/WEB-INF/beans.xml"), "beans.xml");
+				.addAsWebInfResource(new File(projectRootPath + "/api/src/main/webapp/WEB-INF/beans.xml"), "beans.xml")
+				.addAsWebInfResource(new File(projectRootPath + "/api/src/main/webapp/WEB-INF/jboss-deployment-structure.xml"), "jboss-deployment-structure.xml");
 
 		return war;
 	}


### PR DESCRIPTION
Mechanism uses Infinispan Cache for distribution of changed roles. Every request (via RequestWrapper) finds corresponding entry in the cache and if found then it overrides default's roles.

This change also provides new PrincipalWithRoles which contains actual roles so app can easily take all of them.
## Configuration changes

It's needed to configure cache in `standalone.xml`. See [development.md](documentation/development.md) for development.

AS configuration for integration tests needs to reflect this change as well and also needs to have changed Security domain configuration. See [Integration test docs](ftest/README.md) for integration tests.
