### PR TITLE
Fixed 403 return code when is authenticated but doesn't have proper role

### DIFF
--- a/api/src/main/java/org/searchisko/api/rest/SystemRestService.java
+++ b/api/src/main/java/org/searchisko/api/rest/SystemRestService.java
@@ -5,6 +5,9 @@
  */
 package org.searchisko.api.rest;
 
+import java.io.IOException;
+import java.util.Map;
+
 import javax.annotation.security.PermitAll;
 import javax.annotation.security.RolesAllowed;
 import javax.enterprise.context.RequestScoped;
@@ -13,9 +16,10 @@ import javax.ws.rs.GET;
 import javax.ws.rs.Path;
 import javax.ws.rs.Produces;
 import javax.ws.rs.QueryParam;
-import javax.ws.rs.core.*;
-import java.io.IOException;
-import java.util.Map;
+import javax.ws.rs.core.Context;
+import javax.ws.rs.core.MediaType;
+import javax.ws.rs.core.SecurityContext;
+import javax.ws.rs.core.StreamingOutput;
 
 import org.apache.commons.lang.StringUtils;
 import org.elasticsearch.action.search.SearchResponse;
@@ -36,7 +40,7 @@ import org.searchisko.api.service.SystemInfoService;
  */
 @Path("/sys")
 @RequestScoped
-@RolesAllowed(Role.PROVIDER)
+@RolesAllowed(Role.ADMIN)
 @Audit
 public class SystemRestService {
 
@@ -60,7 +64,6 @@ public class SystemRestService {
 	@GET
 	@Path("/auditlog")
 	@Produces(MediaType.APPLICATION_JSON)
-	@RolesAllowed(Role.ADMIN)
 	@AuditIgnore
 	public StreamingOutput getAuditLog(
 			@QueryParam("operation") String operation,

--- a/api/src/main/java/org/searchisko/api/security/Role.java
+++ b/api/src/main/java/org/searchisko/api/security/Role.java
@@ -7,6 +7,16 @@ package org.searchisko.api.security;
  */
 public class Role {
 
+	// When adding new roles:
+	// 1. Add it to ALL_ROLES
+	// 2. Add it to functional tests in searchisko-ftest-users.properties and searchisko-ftest-roles.properties
+
+	public static final String[] ALL_ROLES = {
+			Role.ADMIN,
+			Role.PROVIDER,
+			Role.CONTRIBUTOR
+	};
+
 	/**
 	 * System Admin. The highest permission. Super Provider has this role
 	 */

--- a/ftest/src/test/java/org/searchisko/ftest/rest/IndexerRestServiceTest.java
+++ b/ftest/src/test/java/org/searchisko/ftest/rest/IndexerRestServiceTest.java
@@ -8,8 +8,9 @@ package org.searchisko.ftest.rest;
 import java.io.IOException;
 import java.net.MalformedURLException;
 import java.net.URL;
+import java.util.HashSet;
+import java.util.Set;
 
-import com.jayway.restassured.http.ContentType;
 import org.jboss.arquillian.container.test.api.Deployment;
 import org.jboss.arquillian.junit.Arquillian;
 import org.jboss.arquillian.junit.InSequence;
@@ -17,11 +18,9 @@ import org.jboss.arquillian.test.api.ArquillianResource;
 import org.jboss.shrinkwrap.api.spec.WebArchive;
 import org.junit.Test;
 import org.junit.runner.RunWith;
+import org.searchisko.api.security.Role;
 import org.searchisko.ftest.DeploymentHelpers;
-
-import static com.jayway.restassured.RestAssured.given;
-import static org.hamcrest.Matchers.is;
-import static org.hamcrest.Matchers.not;
+import static org.searchisko.ftest.rest.RestTestHelpers.givenJsonAndLogIfFailsAndAuthPreemptive;
 
 /**
  * Integration test for /indexer REST API.
@@ -33,6 +32,13 @@ import static org.hamcrest.Matchers.not;
  */
 @RunWith(Arquillian.class)
 public class IndexerRestServiceTest {
+
+	public static final Set<String> ALLOWED_ROLES = new HashSet<>();
+
+	static {
+		ALLOWED_ROLES.add(Role.ADMIN);
+		ALLOWED_ROLES.add(Role.PROVIDER);
+	}
 
 	public static final String INDEXER_REST_API = DeploymentHelpers.DEFAULT_REST_VERSION + "indexer/{type}/{operation}";
 
@@ -51,45 +57,54 @@ public class IndexerRestServiceTest {
 	@Test
 	@InSequence(0)
 	public void assertNotAuthenticated() throws MalformedURLException {
-		int expStatus = 401;
+		assertAccess(401, null, null);
+	}
 
+	@Test
+	@InSequence(1)
+	public void assertForbidden() throws MalformedURLException {
+		for (String role : Role.ALL_ROLES) {
+			if (!ALLOWED_ROLES.contains(role)) {
+				assertAccess(403, role, role);
+			}
+		}
+	}
+
+	public void assertAccess(int expStatus, String username, String password) throws MalformedURLException {
 		for (String type : types) {
 			// GET /indexer/{type}/_status
-			given().contentType(ContentType.JSON)
+			givenJsonAndLogIfFailsAndAuthPreemptive(username, password)
 					.pathParam("type", type)
 					.pathParam("operation", "_status")
 					.expect().statusCode(expStatus)
-					.log().ifValidationFails()
 					.when().get(new URL(context, INDEXER_REST_API).toExternalForm());
 
 			// POST /indexer/{type}/_stop
-			given().contentType(ContentType.JSON)
+			givenJsonAndLogIfFailsAndAuthPreemptive(username, password)
 					.pathParam("type", type)
 					.pathParam("operation", "_stop")
 					.expect().statusCode(expStatus)
-					.log().ifStatusCodeMatches(is(not(expStatus)))
 					.when().post(new URL(context, INDEXER_REST_API).toExternalForm());
 
 
 			// POST /indexer/{type}/_restart
-			given().contentType(ContentType.JSON)
+			givenJsonAndLogIfFailsAndAuthPreemptive(username, password)
 					.pathParam("type", type)
 					.pathParam("operation", "_restart")
 					.expect().statusCode(expStatus)
-					.log().ifValidationFails()
 					.when().post(new URL(context, INDEXER_REST_API).toExternalForm());
 
 
 			if (!TYPE_ALL.equals(type)) {
 				// POST /indexer/{type}/_force_reindex
-				given().contentType(ContentType.JSON)
+				givenJsonAndLogIfFailsAndAuthPreemptive(username, password)
 						.pathParam("type", type)
 						.pathParam("operation", "_force_reindex")
 						.expect().statusCode(expStatus)
-						.log().ifValidationFails()
 						.when().post(new URL(context, INDEXER_REST_API).toExternalForm());
 			}
 		}
+
 	}
 
 	//TODO: FTEST: IndexerRestServiceTest: Test start reindex

--- a/ftest/src/test/java/org/searchisko/ftest/rest/RestTestHelpers.java
+++ b/ftest/src/test/java/org/searchisko/ftest/rest/RestTestHelpers.java
@@ -60,4 +60,19 @@ public class RestTestHelpers {
 	public static RequestSpecification givenJsonAndLogIfFailsAndAuthDefaultProvider() {
 		return givenJsonAndLogIfFails().auth().basic(DeploymentHelpers.DEFAULT_PROVIDER_NAME, DeploymentHelpers.DEFAULT_PROVIDER_PASSWORD);
 	}
+
+	/**
+	 * Helper method to get RequestSpecification same as {@link #givenJsonAndLogIfFails()} plus:
+	 * Basic preemptive authentication for give username and password or without it if username and password is null
+	 *
+	 * @param username username or null if no auth. is needed
+	 * @param password password or null if no auth. is needed
+	 * @return
+	 */
+	public static RequestSpecification givenJsonAndLogIfFailsAndAuthPreemptive(String username, String password) {
+		if (username == null && password == null) {
+			return givenJsonAndLogIfFails();
+		}
+		return givenJsonAndLogIfFails().auth().preemptive().basic(username, password);
+	}
 }

--- a/ftest/src/test/resources/searchisko-ftest-roles.properties
+++ b/ftest/src/test/resources/searchisko-ftest-roles.properties
@@ -1,2 +1,7 @@
 contributor1=contributor
 contributor2=contributor,admin
+
+# Role testing.
+# Each username for this test has same role as username
+provider=provider
+contributor=contributor

--- a/ftest/src/test/resources/searchisko-ftest-users.properties
+++ b/ftest/src/test/resources/searchisko-ftest-users.properties
@@ -1,2 +1,8 @@
 contributor1=password1
 contributor2=password2
+
+# Roles testing.
+# Each username is equivalent to searchisko role.
+# Must have same password as username and one role same as username
+provider=provider
+contributor=contributor


### PR DESCRIPTION
fixes #164.
Also added test on 403 to each REST API functional test. Thanks to this functional tests covers not authenticated scenario (401) and also authenticated user with not proper role e.g. `CONTRIBUTOR` (403).
