### PR TITLE
Custom Tags API

### DIFF
--- a/api/src/main/java/org/searchisko/api/rest/CustomTagRestService.java
+++ b/api/src/main/java/org/searchisko/api/rest/CustomTagRestService.java
@@ -1,0 +1,212 @@
+/*
+ * JBoss, Home of Professional Open Source
+ * Copyright 2012 Red Hat Inc. and/or its affiliates and other contributors
+ * as indicated by the @authors tag. All rights reserved.
+ */
+package org.searchisko.api.rest;
+
+import javax.enterprise.context.RequestScoped;
+import javax.inject.Inject;
+import javax.ws.rs.*;
+import javax.ws.rs.core.*;
+import javax.ws.rs.core.Response.Status;
+import java.util.*;
+import java.util.logging.Logger;
+
+import org.elasticsearch.action.get.GetResponse;
+import org.searchisko.api.rest.exception.NotAuthorizedException;
+import org.searchisko.api.rest.exception.RequiredFieldException;
+import org.searchisko.api.security.Role;
+import org.searchisko.api.service.AuthenticationUtilService;
+import org.searchisko.api.service.ProviderService;
+import org.searchisko.api.service.ProviderService.ProviderContentTypeInfo;
+import org.searchisko.api.service.SearchClientService;
+import org.searchisko.api.service.SearchIndexMissingException;
+import org.searchisko.api.util.SearchUtils;
+import org.searchisko.persistence.jpa.model.Tag;
+import org.searchisko.persistence.service.CustomTagPersistenceService;
+
+/**
+ * REST API endpoint for 'Custom Tag API'.
+ *
+ * @author Jiri Mauritz (jirmauritz at gmail dot com)
+ */
+@RequestScoped
+@Path("/tagging")
+@Produces(MediaType.APPLICATION_JSON)
+@Consumes(MediaType.APPLICATION_JSON)
+// Standard Roles are not used because it's designed to return 403 if user is not authenticated.
+//@RolesAllowed({Role.ADMIN, Role.CONTRIBUTOR})
+public class CustomTagRestService extends RestServiceBase {
+
+	public static final String QUERY_PARAM_ID = "id";
+	public static final String DATA_FIELD_TAGGING = "tag";
+
+	@Inject
+	protected Logger log;
+
+	@Inject
+	protected ProviderService providerService;
+
+	@Inject
+	protected SearchClientService searchClientService;
+
+	@Inject
+	protected CustomTagPersistenceService customTagPersistenceService;
+
+	@Inject
+	protected AuthenticationUtilService authenticationUtilService;
+
+	@Context
+	protected SecurityContext securityContext;
+
+	/**
+	 * Custom authentication check if user is in role ${@link org.searchisko.api.security.Role#CONTRIBUTOR}
+	 * or ${@link org.searchisko.api.security.Role#ADMIN}
+	 *
+	 * @throws NotAuthorizedException if user doesn't have required role
+	 */
+	protected void checkIfUserAuthenticated() throws NotAuthorizedException {
+		if (!(securityContext.isUserInRole(Role.CONTRIBUTOR) || securityContext.isUserInRole(Role.ADMIN))) {
+			throw new NotAuthorizedException("User Not Authorized for Content Rating API");
+		}
+	}
+
+	@GET
+	@Path("/{" + QUERY_PARAM_ID + "}")
+	@Produces(MediaType.APPLICATION_JSON)
+	public Object getTagsByContent(@PathParam(QUERY_PARAM_ID) String contentSysId) {
+		checkIfUserAuthenticated();
+
+		contentSysId = SearchUtils.trimToNull(contentSysId);
+
+		// validation
+		if (contentSysId == null) {
+			throw new RequiredFieldException(QUERY_PARAM_ID);
+		}
+
+		List<Tag> tagList = customTagPersistenceService.getTagsByContent(contentSysId);
+		if (tagList != null && !tagList.isEmpty()) {
+			Map<String, Object> result = tagsToJSON(tagList);
+			return result;
+		} else {
+			return Response.status(Status.NOT_FOUND).build();
+		}
+	}
+
+	/**
+	 * Convert {@link Tag} object into JSON map.
+	 *
+	 * @param tags list of tags to convert
+	 * @return JSON map with information about tag
+	 */
+	protected Map<String, Object> tagsToJSON(List<Tag> tags) {
+		Map<String, Object> result = new HashMap<>();
+		result.put("tags", tags);
+		return result;
+	}
+
+	@GET
+	@Path("/")
+	@Produces(MediaType.APPLICATION_JSON)
+	public Object getAllTags() {
+		checkIfUserAuthenticated();
+
+		List<Tag> tagList = customTagPersistenceService.getAllTags();
+		if (tagList != null && !tagList.isEmpty()) {
+			Map<String, Object> result = tagsByContentToJSON(tagList);
+			return result;
+		} else {
+			return Response.status(Status.NOT_FOUND).build();
+		}
+	}
+
+	/**
+	 * Convert {@link Tag} object sorted by content into JSON map.
+	 *
+	 * @param tags list of tags to convert
+	 * @return JSON map with information about tag
+	 */
+	protected Map<String, Object> tagsByContentToJSON(List<Tag> tags) {
+		Map<String, Object> result = new HashMap<>();
+		for (Tag tag : tags) {
+			if (result.containsKey(tag.getContentId())) {
+				((List<String>) result.get(tag.getContentId())).add(tag.getTag());
+			} else {
+				List<String> tl = new ArrayList<>();
+				tl.add(tag.getTag());
+				result.put(tag.getContentId(), tl);
+			}
+		}
+		return result;
+	}
+
+	@POST
+	@Path("/{" + QUERY_PARAM_ID + "}")
+	@Consumes(MediaType.APPLICATION_JSON)
+	@Produces(MediaType.APPLICATION_JSON)
+	public Object postTag(@PathParam(QUERY_PARAM_ID) String contentSysId, Map<String, Object> requestContent) {
+		checkIfUserAuthenticated();
+
+		String currentContributorId = authenticationUtilService.getAuthenticatedContributor(true);
+
+
+		contentSysId = SearchUtils.trimToNull(contentSysId);
+
+		// validation
+		if (contentSysId == null) {
+			throw new RequiredFieldException(QUERY_PARAM_ID);
+		}
+
+		String tag = null;
+		try {
+			tag = (String) requestContent.get(DATA_FIELD_TAGGING);
+		} catch (ClassCastException e) {
+			return Response.status(Status.BAD_REQUEST).entity(DATA_FIELD_TAGGING + " field must be text string").build();
+		}
+		if (tag == null) {
+			throw new RequiredFieldException(DATA_FIELD_TAGGING);
+		}
+
+		if (tag.isEmpty()) {
+			return Response.status(Status.BAD_REQUEST).entity(DATA_FIELD_TAGGING + " field cannot be empty").build();
+		}
+
+		// check if tagged document exists
+		String type = null;
+		try {
+			type = providerService.parseTypeNameFromSysId(contentSysId);
+		} catch (IllegalArgumentException e) {
+			log.fine("bad format or unknown type for content sys_id=" + contentSysId);
+			return Response.status(Response.Status.BAD_REQUEST).entity(QUERY_PARAM_ID + " format is invalid").build();
+		}
+
+		ProviderContentTypeInfo typeInfo = providerService.findContentType(type);
+		if (typeInfo == null) {
+			log.fine("unknown type for content with sys_id=" + contentSysId);
+			return Response.status(Response.Status.NOT_FOUND).entity("content type is unknown").build();
+		}
+
+		String indexName = ProviderService.extractIndexName(typeInfo, type);
+		String indexType = ProviderService.extractIndexType(typeInfo, type);
+
+		try {
+			GetResponse getResponse = searchClientService.performGet(indexName, indexType, contentSysId);
+			if (!getResponse.isExists()) {
+				return Response.status(Response.Status.NOT_FOUND).build();
+			}
+
+			// store tag
+			Tag tagObject = new Tag();
+			tagObject.setContentId(contentSysId);
+			tagObject.setContributorId(currentContributorId);
+			tagObject.setTag(tag);
+			customTagPersistenceService.createTag(tagObject);
+
+			return createResponse(getResponse);
+		} catch (SearchIndexMissingException e) {
+			return Response.status(Response.Status.NOT_FOUND).build();
+		}
+	}
+
+}

--- a/api/src/main/java/org/searchisko/api/rest/CustomTagRestService.java
+++ b/api/src/main/java/org/searchisko/api/rest/CustomTagRestService.java
@@ -75,6 +75,18 @@ public class CustomTagRestService extends RestServiceBase {
 			throw new NotAuthorizedException("User Not Authorized for Tagging API");
 		}
 	}
+        /**
+	 * Custom authentication check if user is in role {@link org.searchisko.api.security.Role#TAGS_MANAGER}
+	 * or {@link org.searchisko.api.security.Role#ADMIN}
+	 *
+	 *
+	 * @throws NotAuthorizedException if user doesn't have required role
+	 */
+	protected void checkIfUserAuthenticated() throws NotAuthorizedException {
+		if (!(authenticationUtilService.isUserInAnyOfRoles(true, Role.TAGS_MANAGER))) {
+			throw new NotAuthorizedException("User Not Authorized for Tagging API");
+		}
+	}
 
 	@GET
 	@Path("/{" + QUERY_PARAM_ID + "}")
@@ -265,7 +277,7 @@ public class CustomTagRestService extends RestServiceBase {
 			return Response.status(Response.Status.NOT_FOUND).entity("content type is unknown").build();
 		}
 
-		checkIfUserAuthenticated(providerService.parseTypeNameFromSysId(contentSysId));
+		checkIfUserAuthenticated();
 
 		// delete tags from custom tags
 		customTagPersistenceService.deleteTagsForContent(contentSysId);
@@ -316,7 +328,7 @@ public class CustomTagRestService extends RestServiceBase {
 			return Response.status(Response.Status.NOT_FOUND).entity("content type is unknown").build();
 		}
 
-		checkIfUserAuthenticated(providerService.parseTypeNameFromSysId(contentSysId));
+		checkIfUserAuthenticated();
 
 		String tagLabel = null;
 		try {

--- a/api/src/main/java/org/searchisko/api/security/Role.java
+++ b/api/src/main/java/org/searchisko/api/security/Role.java
@@ -17,7 +17,8 @@ public class Role {
 			Role.CONTRIBUTOR,
 			Role.CONTRIBUTORS_MANAGER,
 			Role.PROJECTS_MANAGER,
-			Role.TASKS_MANAGER
+			Role.TASKS_MANAGER,
+			Role.TAGS_MANAGER
 	};
 
 	/**
@@ -55,5 +56,12 @@ public class Role {
 	 * @see org.searchisko.api.rest.TaskRestService
 	 */
 	public static final String TASKS_MANAGER = "tasks_manager";
+
+	/**
+	 * User with this role can manage custom tags via Tagging REST API.
+	 *
+	 * @see org.searchisko.api.rest.CustomTagRestService
+	 */
+	public static final String TAGS_MANAGER = "tags_manager";
 
 }

--- a/api/src/main/java/org/searchisko/api/service/CustomTagService.java
+++ b/api/src/main/java/org/searchisko/api/service/CustomTagService.java
@@ -5,10 +5,12 @@
  */
 package org.searchisko.api.service;
 
+import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.TreeSet;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
@@ -106,13 +108,17 @@ public class CustomTagService {
 	public void updateSysTagsField(Map<String,Object> source) {
 		List<String> tags = (List<String>) source.get(ContentObjectFields.TAGS);
 		List<Tag> customTags = customTagPersistenceService.getTagsByContent((String) source.get(ContentObjectFields.SYS_ID));
-		Set<String> sysTags = new HashSet<>();
+		Set<String> sysTags = new TreeSet<>(String.CASE_INSENSITIVE_ORDER);
 
-		sysTags.addAll(tags);
 		for (Tag tag : customTags) {
 			sysTags.add(tag.getTagLabel());
 		}
 
-		source.put(ContentObjectFields.SYS_TAGS, sysTags);
+		if (tags != null) {
+			sysTags.addAll(tags);
+		}
+
+
+		source.put(ContentObjectFields.SYS_TAGS, new ArrayList<String>(sysTags));
 	}
 }

--- a/api/src/main/java/org/searchisko/api/service/CustomTagService.java
+++ b/api/src/main/java/org/searchisko/api/service/CustomTagService.java
@@ -27,13 +27,13 @@ import org.searchisko.persistence.service.CustomTagPersistenceService;
 @Named
 @ApplicationScoped
 @Singleton
-public class CustomTagsService {
+public class CustomTagService {
 
 	@Inject
 	protected Logger log;
 
 	@Inject
-	protected CustomTagPersistenceService customTagsPersistenceService;
+	protected CustomTagPersistenceService customTagPersistenceService;
 
 	/**
 	 * CDI Event handler for {@link ContentDeletedEvent} used to remove ratings when content is deleted.
@@ -43,7 +43,7 @@ public class CustomTagsService {
 	public void contentDeletedEventHandler(@Observes ContentDeletedEvent event) {
 		log.log(Level.FINE, "contentDeletedEventHandler called for event {0}", event);
 		if (event != null && event.getContentId() != null) {
-			customTagsPersistenceService.deleteTagsForContent(event.getContentId());
+			customTagPersistenceService.deleteTagsForContent(event.getContentId());
 		} else {
 			log.warning("Invalid event " + event);
 		}
@@ -56,7 +56,7 @@ public class CustomTagsService {
 	 */
 	public void contributorMergedEventHandler(@Observes ContributorMergedEvent event) {
 		if (event != null && event.getContributorCodeFrom() != null && event.getContributorCodeTo() != null) {
-			customTagsPersistenceService.changeOwnershipOfTags(event.getContributorCodeFrom(), event.getContributorCodeTo());
+			customTagPersistenceService.changeOwnershipOfTags(event.getContributorCodeFrom(), event.getContributorCodeTo());
 		} else {
 			log.warning("Invalid event " + event);
 		}

--- a/api/src/main/java/org/searchisko/api/service/CustomTagService.java
+++ b/api/src/main/java/org/searchisko/api/service/CustomTagService.java
@@ -5,6 +5,13 @@
  */
 package org.searchisko.api.service;
 
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.SortedSet;
+import java.util.TreeSet;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
@@ -13,9 +20,11 @@ import javax.enterprise.context.ApplicationScoped;
 import javax.enterprise.event.Observes;
 import javax.inject.Inject;
 import javax.inject.Named;
+import org.searchisko.api.ContentObjectFields;
 
 import org.searchisko.api.events.ContentDeletedEvent;
 import org.searchisko.api.events.ContributorMergedEvent;
+import org.searchisko.persistence.jpa.model.Tag;
 import org.searchisko.persistence.service.CustomTagPersistenceService;
 
 /**
@@ -62,5 +71,16 @@ public class CustomTagService {
 		}
 	}
 
+	public void updateSysTagsField(Map<String,Object> source) {
+		List<String> tags = (List<String>) source.get(ContentObjectFields.TAGS);
+		List<Tag> customTags = customTagPersistenceService.getTagsByContent((String) source.get(ContentObjectFields.SYS_ID));
+		Set<String> sysTags = new HashSet<>();
 
+		sysTags.addAll(tags);
+		for (Tag tag : customTags) {
+			sysTags.add(tag.getTagLabel());
+		}
+
+		source.put(ContentObjectFields.SYS_TAGS, sysTags);
+	}
 }

--- a/api/src/main/java/org/searchisko/api/service/CustomTagsService.java
+++ b/api/src/main/java/org/searchisko/api/service/CustomTagsService.java
@@ -1,0 +1,46 @@
+/*
+ * JBoss, Home of Professional Open Source
+ * Copyright 2014 Red Hat Inc. and/or its affiliates and other contributors
+ * as indicated by the @authors tag. All rights reserved.
+ */
+package org.searchisko.api.service;
+
+import java.util.Map;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+
+import javax.ejb.Singleton;
+import javax.enterprise.context.ApplicationScoped;
+import javax.enterprise.event.Observes;
+import javax.inject.Inject;
+import javax.inject.Named;
+
+import org.searchisko.api.ContentObjectFields;
+import org.searchisko.api.events.ContentBeforeIndexedEvent;
+import org.searchisko.api.events.ContentDeletedEvent;
+import org.searchisko.api.events.ContributorCodeChangedEvent;
+import org.searchisko.api.events.ContributorDeletedEvent;
+import org.searchisko.api.events.ContributorMergedEvent;
+import org.searchisko.persistence.service.RatingPersistenceService;
+import org.searchisko.persistence.service.RatingPersistenceService.RatingStats;
+
+/**
+ * Business logic for Custom Tags. It can provide some more complicated operations at top of
+ * {@link CustomTagPersistenceService} but you can use {@link CustomTagPersistenceService} directly when appropriate.
+ *
+ * @author Jiri Mauritz (jirmauritz at gmail dot com)
+ */
+@Named
+@ApplicationScoped
+@Singleton
+public class CustomTagsService {
+
+	@Inject
+	protected Logger log;
+
+	@Inject
+	protected RatingPersistenceService ratingPersistenceService;
+
+	
+
+}

--- a/api/src/main/java/org/searchisko/api/service/CustomTagsService.java
+++ b/api/src/main/java/org/searchisko/api/service/CustomTagsService.java
@@ -5,7 +5,6 @@
  */
 package org.searchisko.api.service;
 
-import java.util.Map;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
@@ -15,14 +14,9 @@ import javax.enterprise.event.Observes;
 import javax.inject.Inject;
 import javax.inject.Named;
 
-import org.searchisko.api.ContentObjectFields;
-import org.searchisko.api.events.ContentBeforeIndexedEvent;
 import org.searchisko.api.events.ContentDeletedEvent;
-import org.searchisko.api.events.ContributorCodeChangedEvent;
-import org.searchisko.api.events.ContributorDeletedEvent;
 import org.searchisko.api.events.ContributorMergedEvent;
-import org.searchisko.persistence.service.RatingPersistenceService;
-import org.searchisko.persistence.service.RatingPersistenceService.RatingStats;
+import org.searchisko.persistence.service.CustomTagPersistenceService;
 
 /**
  * Business logic for Custom Tags. It can provide some more complicated operations at top of
@@ -39,8 +33,34 @@ public class CustomTagsService {
 	protected Logger log;
 
 	@Inject
-	protected RatingPersistenceService ratingPersistenceService;
+	protected CustomTagPersistenceService customTagsPersistenceService;
 
-	
+	/**
+	 * CDI Event handler for {@link ContentDeletedEvent} used to remove ratings when content is deleted.
+	 *
+	 * @param event to process
+	 */
+	public void contentDeletedEventHandler(@Observes ContentDeletedEvent event) {
+		log.log(Level.FINE, "contentDeletedEventHandler called for event {0}", event);
+		if (event != null && event.getContentId() != null) {
+			customTagsPersistenceService.deleteTagsForContent(event.getContentId());
+		} else {
+			log.warning("Invalid event " + event);
+		}
+	}
+
+	/**
+	 * CDI event handler for {@link ContributorMergedEvent} used to merge ratings from both Contibutors to final one.
+	 *
+	 * @param event
+	 */
+	public void contributorMergedEventHandler(@Observes ContributorMergedEvent event) {
+		if (event != null && event.getContributorCodeFrom() != null && event.getContributorCodeTo() != null) {
+			customTagsPersistenceService.changeOwnershipOfTags(event.getContributorCodeFrom(), event.getContributorCodeTo());
+		} else {
+			log.warning("Invalid event " + event);
+		}
+	}
+
 
 }

--- a/api/src/main/java/org/searchisko/persistence/jpa/model/Tag.java
+++ b/api/src/main/java/org/searchisko/persistence/jpa/model/Tag.java
@@ -1,0 +1,135 @@
+/*
+ * JBoss, Home of Professional Open Source
+ * Copyright 2013 Red Hat Inc. and/or its affiliates and other contributors
+ * as indicated by the @authors tag. All rights reserved.
+ */
+package org.searchisko.persistence.jpa.model;
+
+import java.io.Serializable;
+import java.sql.Timestamp;
+
+import javax.persistence.Entity;
+import javax.persistence.GeneratedValue;
+import javax.persistence.Id;
+import javax.validation.constraints.NotNull;
+
+/**
+ * Custom tag entity class. Class is JPA annotated.
+ *
+ * @author Jiri Mauritz (jirmauritz at gmail dot com)
+ */
+@Entity
+public class Tag implements Serializable {
+
+	@Id
+	@GeneratedValue
+	private long id;
+
+	/**
+	 * Id of the content this tag belogs to.
+	 */
+	@NotNull
+	private String contentId;
+
+	/**
+	 * Id of the contributor who created the tag.
+	 */
+	@NotNull
+	private String contributorId;
+
+	/**
+	 * Text representation of the tag.
+	 */
+	@NotNull
+	private String tag;
+
+	/**
+	 * Timestamp when tag has been created last time.
+	 */
+	@NotNull
+	private Timestamp createdAt;
+
+	/**
+	 * Basic constructor.
+	 */
+	public Tag() {
+		super();
+	}
+
+	public Tag(String contentId, String contributorId, String tag, Timestamp createdAt) {
+		this.contentId = contentId;
+		this.contributorId = contributorId;
+		this.tag = tag;
+		this.createdAt = createdAt;
+	}
+
+	public String getContentId() {
+		return contentId;
+	}
+
+	public void setContentId(String contentId) {
+		this.contentId = contentId;
+	}
+
+	public String getContributorId() {
+		return contributorId;
+	}
+
+	public void setContributorId(String contributorId) {
+		this.contributorId = contributorId;
+	}
+
+	public String getTag() {
+		return tag;
+	}
+
+	public void setTag(String tag) {
+		this.tag = tag;
+	}
+
+	public Timestamp getCreatedAt() {
+		return createdAt;
+	}
+
+	public void setCreatedAt(Timestamp createdAt) {
+		this.createdAt = createdAt;
+	}
+
+	public long getId() {
+		return id;
+	}
+
+	public void setId(long id) {
+		this.id = id;
+	}
+
+	@Override
+	public int hashCode() {
+		int hash = 3;
+		hash = 67 * hash + (int) (this.id ^ (this.id >>> 32));
+		return hash;
+	}
+
+	@Override
+	public boolean equals(Object obj) {
+		if (this == obj)
+			return true;
+		if (obj == null)
+			return false;
+		if (getClass() != obj.getClass())
+			return false;
+		Tag other = (Tag) obj;
+		if (id != other.id)
+			return false;
+		if (id == 0)
+			return obj == this;
+		return true;
+	}
+
+	@Override
+	public String toString() {
+		return "Tag{" + "id=" + id + ", contentId=" + contentId + ", contributorId=" + contributorId +
+			", tag=" + tag + ", createdAt=" + createdAt + '}';
+	}
+
+}

--- a/api/src/main/java/org/searchisko/persistence/jpa/model/Tag.java
+++ b/api/src/main/java/org/searchisko/persistence/jpa/model/Tag.java
@@ -1,7 +1,7 @@
 /*
  * JBoss, Home of Professional Open Source
  * Copyright 2013 Red Hat Inc. and/or its affiliates and other contributors
- * as indicated by the @authors tag. All rights reserved.
+ * as indicated by the @authors tagLabel. All rights reserved.
  */
 package org.searchisko.persistence.jpa.model;
 
@@ -14,7 +14,7 @@ import javax.persistence.Id;
 import javax.validation.constraints.NotNull;
 
 /**
- * Custom tag entity class. Class is JPA annotated.
+ * Custom tagLabel entity class. Class is JPA annotated.
  *
  * @author Jiri Mauritz (jirmauritz at gmail dot com)
  */
@@ -26,25 +26,24 @@ public class Tag implements Serializable {
 	private long id;
 
 	/**
-	 * Id of the content this tag belogs to.
+	 * Id of the content this tagLabel belogs to.
 	 */
 	@NotNull
 	private String contentId;
 
 	/**
-	 * Id of the contributor who created the tag.
+	 * Id of the contributor who created the tagLabel.
 	 */
 	@NotNull
 	private String contributorId;
 
 	/**
-	 * Text representation of the tag.
+	 * Text representation of the tagLabel.
 	 */
-	@NotNull
-	private String tag;
+	private String tagLabel;
 
 	/**
-	 * Timestamp when tag has been created last time.
+	 * Timestamp when tagLabel has been created last time.
 	 */
 	@NotNull
 	private Timestamp createdAt;
@@ -56,10 +55,10 @@ public class Tag implements Serializable {
 		super();
 	}
 
-	public Tag(String contentId, String contributorId, String tag, Timestamp createdAt) {
+	public Tag(String contentId, String contributorId, String tagLabel, Timestamp createdAt) {
 		this.contentId = contentId;
 		this.contributorId = contributorId;
-		this.tag = tag;
+		this.tagLabel = tagLabel;
 		this.createdAt = createdAt;
 	}
 
@@ -79,12 +78,12 @@ public class Tag implements Serializable {
 		this.contributorId = contributorId;
 	}
 
-	public String getTag() {
-		return tag;
+	public String getTagLabel() {
+		return tagLabel;
 	}
 
-	public void setTag(String tag) {
-		this.tag = tag;
+	public void setTagLabel(String tagLabel) {
+		this.tagLabel = tagLabel;
 	}
 
 	public Timestamp getCreatedAt() {
@@ -119,17 +118,45 @@ public class Tag implements Serializable {
 		if (getClass() != obj.getClass())
 			return false;
 		Tag other = (Tag) obj;
-		if (id != other.id)
+
+		if (!(getContentId().equals(other.getContentId()))) {
 			return false;
-		if (id == 0)
-			return obj == this;
-		return true;
+		}
+
+		if (!(getTagLabel().equals(other.getTagLabel()))) {
+			return false;
+		}
+
+		return compareTagLabels(getTagLabel(), other.getTagLabel());
+	}
+
+	/**
+	 * Decides if first tag label equals second.
+	 *
+	 * @param first tag label
+	 * @param second tag label
+	 * @return true if they are equal
+	 */
+	private boolean compareTagLabels(String first, String second) {
+		if (first == null) {
+			return second == null;
+		}
+
+		// trim whitespaces
+		first = first.trim();
+		second = second.trim();
+
+		// to lower case
+		first = first.toLowerCase();
+		second = second.toLowerCase();
+
+		return first.equals(second);
 	}
 
 	@Override
 	public String toString() {
 		return "Tag{" + "id=" + id + ", contentId=" + contentId + ", contributorId=" + contributorId +
-			", tag=" + tag + ", createdAt=" + createdAt + '}';
+			", tag=" + tagLabel + ", createdAt=" + createdAt + '}';
 	}
 
 }

--- a/api/src/main/java/org/searchisko/persistence/jpa/model/Tag.java
+++ b/api/src/main/java/org/searchisko/persistence/jpa/model/Tag.java
@@ -41,6 +41,7 @@ public class Tag implements Serializable, Comparable {
 	/**
 	 * Text representation of the tagLabel.
 	 */
+	@NotNull
 	private String tagLabel;
 
 	/**
@@ -56,11 +57,10 @@ public class Tag implements Serializable, Comparable {
 		super();
 	}
 
-	public Tag(String contentId, String contributorId, String tagLabel, Timestamp createdAt) {
+	public Tag(String contentId, String contributorId, String tagLabel) {
 		this.contentId = contentId;
 		this.contributorId = contributorId;
 		this.tagLabel = tagLabel;
-		this.createdAt = createdAt;
 	}
 
 	public String getContentId() {

--- a/api/src/main/java/org/searchisko/persistence/jpa/model/Tag.java
+++ b/api/src/main/java/org/searchisko/persistence/jpa/model/Tag.java
@@ -7,6 +7,7 @@ package org.searchisko.persistence.jpa.model;
 
 import java.io.Serializable;
 import java.sql.Timestamp;
+import java.util.Comparator;
 
 import javax.persistence.Entity;
 import javax.persistence.GeneratedValue;
@@ -19,7 +20,7 @@ import javax.validation.constraints.NotNull;
  * @author Jiri Mauritz (jirmauritz at gmail dot com)
  */
 @Entity
-public class Tag implements Serializable {
+public class Tag implements Serializable, Comparable {
 
 	@Id
 	@GeneratedValue
@@ -119,38 +120,30 @@ public class Tag implements Serializable {
 			return false;
 		Tag other = (Tag) obj;
 
-		if (!(getContentId().equals(other.getContentId()))) {
+		if (getId() != other.getId()) {
 			return false;
 		}
 
-		if (!(getTagLabel().equals(other.getTagLabel()))) {
-			return false;
-		}
-
-		return compareTagLabels(getTagLabel(), other.getTagLabel());
+		return true;
 	}
 
-	/**
-	 * Decides if first tag label equals second.
-	 *
-	 * @param first tag label
-	 * @param second tag label
-	 * @return true if they are equal
-	 */
-	private boolean compareTagLabels(String first, String second) {
-		if (first == null) {
-			return second == null;
+	@Override
+	public int compareTo(Object o) {
+		if (o == null)
+			return 1;
+		if (getClass() != o.getClass())
+			return 1;
+		Tag other = (Tag) o;
+
+		if (getId() == other.getId()) {
+			return 0;
 		}
 
-		// trim whitespaces
-		first = first.trim();
-		second = second.trim();
-
-		// to lower case
-		first = first.toLowerCase();
-		second = second.toLowerCase();
-
-		return first.equals(second);
+		if (getId() > other.getId()) {
+			return 1;
+		} else {
+			return -1;
+		}
 	}
 
 	@Override

--- a/api/src/main/java/org/searchisko/persistence/service/CustomTagPersistenceService.java
+++ b/api/src/main/java/org/searchisko/persistence/service/CustomTagPersistenceService.java
@@ -26,7 +26,7 @@ public interface CustomTagPersistenceService {
 
 	/**
 	 * Get tags for all contents. It can be used for tagcloud and others.
-	 * 
+	 *
 	 * @return list of tags
 	 */
 	List<Tag> getAllTags();
@@ -35,15 +35,19 @@ public interface CustomTagPersistenceService {
 	 * Creates tag for the content given in the tag object parameter.
 	 *
 	 * @param tag representation of the tag
+	 * @return false, if tag alrady exists for given content
+	 *
 	 */
-	void createTag(Tag tag);
+	boolean createTag(Tag tag);
 
 	/**
 	 * Deletes tag for the content given in the tag object parameter.
 	 *
-	 * @param tag
+	 * @param contentId identifier of the content
+	 * @param tagLabel string representation of tag
+	 *
 	 */
-	void deleteTag(Tag tag);
+	void deleteTag(String contentId, String tagLabel);
 
 	/**
 	 * Deletes all tags for given content.
@@ -51,5 +55,13 @@ public interface CustomTagPersistenceService {
 	 * @param contentId to delete tags for
 	 */
 	void deleteTagsForContent(String... contentId);
+
+	/**
+	 * Changes ownership of all tags that belong to contributorFrom to contributorTo.
+	 *
+	 * @param contributorFrom id of contributor
+	 * @param contributorTo  id of contributor
+	 */
+	void changeOwnershipOfTags(String contributorFrom, String contributorTo);
 
 }

--- a/api/src/main/java/org/searchisko/persistence/service/CustomTagPersistenceService.java
+++ b/api/src/main/java/org/searchisko/persistence/service/CustomTagPersistenceService.java
@@ -1,0 +1,55 @@
+/*
+ * JBoss, Home of Professional Open Source
+ * Copyright 2013 Red Hat Inc. and/or its affiliates and other contributors
+ * as indicated by the @authors tag. All rights reserved.
+ */
+package org.searchisko.persistence.service;
+
+import java.util.List;
+import org.searchisko.persistence.jpa.model.Tag;
+
+
+/**
+ * Interface for service used to persistently store "Custom tag"s.
+ *
+ * @author Jiri Mauritz (jirmauritz at gmail dot com)
+ */
+public interface CustomTagPersistenceService {
+
+	/**
+	 * Get all custom tags for given content.
+	 *
+	 * @param contentId identifier of the content
+	 * @return list of tags
+	 */
+	List<Tag> getTagsByContent(String... contentId);
+
+	/**
+	 * Get tags for all contents. It can be used for tagcloud and others.
+	 * 
+	 * @return list of tags
+	 */
+	List<Tag> getAllTags();
+
+	/**
+	 * Creates tag for the content given in the tag object parameter.
+	 *
+	 * @param tag representation of the tag
+	 */
+	void createTag(Tag tag);
+
+	/**
+	 * Deletes tag for the content given in the tag object parameter.
+	 *
+	 * @param tag
+	 */
+	void deleteTag(Tag tag);
+
+	/**
+	 * Deletes all tags for given content.
+	 *
+	 * @param contentId to delete tags for
+	 */
+	void deleteTagsForContent(String... contentId);
+
+}

--- a/api/src/main/java/org/searchisko/persistence/service/CustomTagPersistenceService.java
+++ b/api/src/main/java/org/searchisko/persistence/service/CustomTagPersistenceService.java
@@ -25,11 +25,12 @@ public interface CustomTagPersistenceService {
 	List<Tag> getTagsByContent(String... contentId);
 
 	/**
-	 * Get tags for all contents. It can be used for tagcloud and others.
+	 * Get all tags for content type.
 	 *
-	 * @return list of tags
+	 * @param contentType id of contentType
+	 * @return list of tags for content type
 	 */
-	List<Tag> getAllTags();
+	List<Tag> getTagsByContentType(String contentType);
 
 	/**
 	 * Creates tag for the content given in the tag object parameter.

--- a/api/src/main/java/org/searchisko/persistence/service/JpaCustomTagPersistenceService.java
+++ b/api/src/main/java/org/searchisko/persistence/service/JpaCustomTagPersistenceService.java
@@ -1,0 +1,78 @@
+/*
+ * JBoss, Home of Professional Open Source
+ * Copyright 2013 Red Hat Inc. and/or its affiliates and other contributors
+ * as indicated by the @authors tag. All rights reserved.
+ */
+package org.searchisko.persistence.service;
+
+import java.sql.Timestamp;
+import java.util.Arrays;
+import java.util.List;
+
+import javax.ejb.LocalBean;
+import javax.ejb.Stateless;
+import javax.inject.Inject;
+import javax.persistence.EntityManager;
+import javax.persistence.TypedQuery;
+import javax.persistence.criteria.CriteriaBuilder;
+import javax.persistence.criteria.CriteriaQuery;
+import javax.persistence.criteria.Root;
+
+import org.searchisko.persistence.jpa.model.Tag;
+
+/**
+ * JPA based implementation of {@link CustomTagPersistenceService}.
+ *
+ * @author Jiri Mauritz (jirmauritz at gmail dot com)
+ */
+@Stateless
+@LocalBean
+public class JpaCustomTagPersistenceService implements CustomTagPersistenceService {
+
+	@Inject
+	protected EntityManager em;
+
+	@Override
+	public List<Tag> getTagsByContent(String... contentId) {
+		CriteriaBuilder cb = em.getCriteriaBuilder();
+		CriteriaQuery<Tag> queryList = cb.createQuery(Tag.class);
+		Root<Tag> tagRoot = queryList.from(Tag.class);
+		queryList.select(tagRoot);
+		queryList.where(cb.isTrue(tagRoot.get("contentId").in((Object[]) contentId)));
+		TypedQuery<Tag> q = em.createQuery(queryList);
+		return q.getResultList();
+	}
+
+	@Override
+	public List<Tag> getAllTags() {
+		return em.createQuery("from Tag").getResultList();
+	}
+
+	@Override
+	public void createTag(Tag tag) {
+		// check if there is same tag for the same content
+		List<Tag> tagList = getTagsByContent(tag.getContentId());
+		if (tagList.contains(tag)) {
+			// tag already exists
+			// TODO: return HTTP code already exists
+			return;
+		}
+		tag.setCreatedAt(new Timestamp(System.currentTimeMillis()));
+		em.persist(tag);
+	}
+
+	@Override
+	public void deleteTag(Tag tag) {
+		if (tag != null)
+			// spravit - misto tag pride contentId a tag(string)
+			em.createQuery("delete from Tag t where t = ?1").setParameter(1, tag).executeUpdate();
+	}
+
+	@Override
+	public void deleteTagsForContent(String... contentId) {
+		if (contentId != null && contentId.length > 0)
+			em.createQuery("delete from Tag t where t.contentId in ?1").setParameter(1, Arrays.asList(contentId))
+					.executeUpdate();
+	}
+
+}

--- a/api/src/main/java/org/searchisko/persistence/service/JpaCustomTagPersistenceService.java
+++ b/api/src/main/java/org/searchisko/persistence/service/JpaCustomTagPersistenceService.java
@@ -8,6 +8,8 @@ package org.searchisko.persistence.service;
 import java.sql.Timestamp;
 import java.util.Arrays;
 import java.util.List;
+import java.util.SortedSet;
+import java.util.TreeSet;
 
 import javax.ejb.LocalBean;
 import javax.ejb.Stateless;
@@ -51,8 +53,12 @@ public class JpaCustomTagPersistenceService implements CustomTagPersistenceServi
 	@Override
 	public boolean createTag(Tag tag) {
 		// check if there is same tag for the same content
-		List<Tag> tagList = getTagsByContent(tag.getContentId());
-		if (tagList.contains(tag)) {
+		SortedSet<String> tagList = new TreeSet(String.CASE_INSENSITIVE_ORDER);
+		for (Tag item : getTagsByContent(tag.getContentId())) {
+			tagList.add(item.getTagLabel());
+		}
+
+		if (tagList.contains(tag.getTagLabel())) {
 			// tag already exists
 			return false;
 		}

--- a/api/src/test/java/org/searchisko/api/rest/CustomTagRestServiceTest.java
+++ b/api/src/test/java/org/searchisko/api/rest/CustomTagRestServiceTest.java
@@ -1,0 +1,521 @@
+/*
+ * JBoss, Home of Professional Open Source
+ * Copyright 2013 Red Hat Inc. and/or its affiliates and other contributors
+ * as indicated by the @authors tag. All rights reserved.
+ */
+package org.searchisko.api.rest;
+
+import java.sql.Timestamp;
+import javax.ws.rs.core.Response.Status;
+import javax.ws.rs.core.SecurityContext;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.logging.Logger;
+
+import org.elasticsearch.action.get.GetResponse;
+import org.junit.Assert;
+import org.junit.Test;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mockito;
+import org.searchisko.api.rest.exception.RequiredFieldException;
+import org.searchisko.api.service.AuthenticationUtilService;
+import org.searchisko.api.service.CustomTagService;
+import org.searchisko.api.service.ProviderService;
+import org.searchisko.api.service.ProviderServiceTest;
+import org.searchisko.api.service.SearchClientService;
+import org.searchisko.api.service.SearchIndexMissingException;
+import org.searchisko.api.testtools.TestUtils;
+import org.searchisko.persistence.jpa.model.Tag;
+import org.searchisko.persistence.service.CustomTagPersistenceService;
+
+/**
+ * Unit test for {@link CustomTagRestService}
+ *
+ * @author Jiri Mauritz (jirmauritz at gmail dot com)
+ */
+public class CustomTagRestServiceTest {
+
+	private static final String MOCK_TYPE_NAME = "mytype";
+	private static final String MOCK_INDEX_NAME = "myindex";
+	private static final String MOCK_CONTENT_ID_1 = "jb-45";
+	private static final String MOCK_CONTENT_ID_2 = "jb-425";
+	private static final String MOCK_CONTENT_ID_3 = "jb-456";
+	private static final String MOCK_CONTENT_TYPE = "jb";
+	private static final String MOCK_CONTRIB_ID = "test <test@test.org>";
+
+	@Test(expected = RequiredFieldException.class)
+	public void getTagsByContent_invalidParam_1() {
+		CustomTagRestService tested = getTested();
+		tested.getTagsByContent(null);
+	}
+
+	@Test(expected = RequiredFieldException.class)
+	public void getTagsByContent_invalidParam_2() {
+		CustomTagRestService tested = getTested();
+		tested.getTagsByContent(" ");
+	}
+
+	@Test
+	public void getTagsByContent() {
+		CustomTagRestService tested = getTested();
+		prepareContentId(tested);
+
+		// case - no tag in DB, null returned from service
+		{
+			Mockito.when(
+					tested.customTagPersistenceService.getTagsByContent(Mockito.eq(MOCK_CONTENT_ID_1)))
+					.thenReturn(null);
+			TestUtils.assertResponseStatus(tested.getTagsByContent(MOCK_CONTENT_ID_1), Status.NOT_FOUND);
+			Mockito.verify(tested.customTagPersistenceService).getTagsByContent(Mockito.eq(MOCK_CONTENT_ID_1));
+		}
+
+		// case - no tag in DB, empty list returned from service
+		{
+			Mockito.reset(tested.customTagPersistenceService);
+			Mockito.when(
+					tested.customTagPersistenceService.getTagsByContent(Mockito.eq(MOCK_CONTENT_ID_1)))
+					.thenReturn(new ArrayList<Tag>());
+			TestUtils.assertResponseStatus(tested.getTagsByContent(MOCK_CONTENT_ID_1), Status.NOT_FOUND);
+			Mockito.verify(tested.customTagPersistenceService).getTagsByContent(Mockito.eq(MOCK_CONTENT_ID_1));
+		}
+
+		// case - tag in DB so returned
+		{
+			List<Tag> tags = new ArrayList<Tag>();
+			tags.add(new Tag(MOCK_CONTENT_ID_1, MOCK_CONTRIB_ID, "label"));
+			Mockito.reset(tested.customTagPersistenceService);
+			Mockito.when(
+					tested.customTagPersistenceService.getTagsByContent(Mockito.eq(MOCK_CONTENT_ID_1)))
+					.thenReturn(tags);
+			@SuppressWarnings("unchecked")
+			Map<String, Object> aret = (Map<String, Object>) tested.getTagsByContent(MOCK_CONTENT_ID_1);
+			List<String> testingList = new ArrayList<>();
+			testingList.add("label");
+			assertCustomTagJSON(aret, testingList);
+		}
+	}
+
+	protected void assertCustomTagJSON(Map<String, Object> customTagJsonMap, List<String> labels) {
+		Assert.assertNotNull(customTagJsonMap);
+		Assert.assertEquals(1, customTagJsonMap.size());
+		Assert.assertEquals(labels, customTagJsonMap.get(CustomTagRestService.DATA_FIELD_TAGGING));
+	}
+
+	@Test(expected = RequiredFieldException.class)
+	public void getTagsByContentType_invalidParam_1() {
+		CustomTagRestService tested = getTested();
+		tested.getTagsByContentType(null);
+	}
+
+	@Test(expected = RequiredFieldException.class)
+	public void getTagsByContentType_invalidParam_2() {
+		CustomTagRestService tested = getTested();
+		tested.getTagsByContentType(" ");
+	}
+
+	@SuppressWarnings("unchecked")
+	@Test
+	public void getTagsByContentType() {
+		CustomTagRestService tested = getTested();
+		Map<String, Object> typeDef = mockTypeDef();
+		Mockito.when(tested.providerService.findContentType(MOCK_CONTENT_TYPE)).thenReturn(
+					ProviderServiceTest.createProviderContentTypeInfo(typeDef));
+
+		// case - no tags in DB, null returned from service
+		{
+			Mockito.when(
+					tested.customTagPersistenceService.getTagsByContentType(Mockito.anyString()))
+					.thenReturn(null);
+			TestUtils.assertResponseStatus(tested.getTagsByContentType(MOCK_CONTENT_TYPE), Status.NOT_FOUND);
+			Mockito.verify(tested.customTagPersistenceService).getTagsByContentType(MOCK_CONTENT_TYPE);
+		}
+
+		// case - no customTag in DB, empty list returned from service
+		{
+			Mockito.reset(tested.customTagPersistenceService);
+			Mockito.when(
+					tested.customTagPersistenceService.getTagsByContentType(Mockito.anyString()))
+					.thenReturn(new ArrayList<Tag>());
+			TestUtils.assertResponseStatus(tested.getTagsByContentType(MOCK_CONTENT_TYPE), Status.NOT_FOUND);
+			Mockito.verify(tested.customTagPersistenceService).getTagsByContentType(MOCK_CONTENT_TYPE);
+		}
+
+		// case - customTag in DB so returned
+		{
+			List<Tag> tags = new ArrayList<Tag>();
+			tags.add(new Tag(MOCK_CONTENT_ID_1, MOCK_CONTRIB_ID, "label1"));
+			tags.add(new Tag(MOCK_CONTENT_ID_2, MOCK_CONTRIB_ID, "label2"));
+			Mockito.reset(tested.customTagPersistenceService);
+			Mockito.when(
+					tested.customTagPersistenceService.getTagsByContentType(MOCK_CONTENT_TYPE)).thenReturn(tags);
+			Map<String, Object> aret = (Map<String, Object>) tested.getTagsByContentType(MOCK_CONTENT_TYPE);
+			Mockito.verify(tested.customTagPersistenceService).getTagsByContentType(MOCK_CONTENT_TYPE);
+			List<String> testingList = new ArrayList<>();
+			testingList.add("label1");
+			testingList.add("label2");
+			assertCustomTagJSON(aret, testingList);
+		}
+	}
+
+	@Test(expected = RequiredFieldException.class)
+	public void postTag_invalidParam_contentSysId_1() {
+		CustomTagRestService tested = getTested();
+		Map<String, Object> content = new HashMap<>();
+		content.put(CustomTagRestService.DATA_FIELD_TAGGING, "label");
+		tested.postTag(null, content);
+	}
+
+	@Test(expected = RequiredFieldException.class)
+	public void postTag_invalidParam_contentSysId_2() {
+		CustomTagRestService tested = getTested();
+		Map<String, Object> content = new HashMap<>();
+		content.put(CustomTagRestService.DATA_FIELD_TAGGING, "label");
+		tested.postTag(" ", content);
+	}
+
+	@Test
+	public void postTag_invalidParam_contentSysId_3() {
+		CustomTagRestService tested = getTested();
+		Map<String, Object> content = new HashMap<>();
+		content.put(CustomTagRestService.DATA_FIELD_TAGGING, "label");
+
+		// invalid format of contentSysId checked over providerService
+		Mockito.when(tested.providerService.parseTypeNameFromSysId("aa")).thenThrow(new IllegalArgumentException());
+		TestUtils.assertResponseStatus(tested.postTag("aa", content), Status.BAD_REQUEST);
+	}
+
+	@Test(expected = RequiredFieldException.class)
+	public void postTag_invalidParam_customTagValue_1() {
+		CustomTagRestService tested = getTested();
+		tested.postTag(MOCK_CONTENT_ID_1, null);
+	}
+
+	@Test(expected = RequiredFieldException.class)
+	public void postTag_invalidParam_customTagValue_2() {
+		CustomTagRestService tested = getTested();
+		prepareContentId(tested);
+		Map<String, Object> content = new HashMap<>();
+		tested.postTag(MOCK_CONTENT_ID_1, content);
+	}
+
+	@Test
+	public void postTag_invalidParam_customTagValue_3() {
+		CustomTagRestService tested = getTested();
+		prepareContentId(tested);
+		Map<String, Object> content = new HashMap<>();
+		content.put(CustomTagRestService.DATA_FIELD_TAGGING, new Object());
+		TestUtils.assertResponseStatus(tested.postTag(MOCK_CONTENT_ID_1, content), Status.BAD_REQUEST);
+
+		content.put(CustomTagRestService.DATA_FIELD_TAGGING, new Integer(6));
+		TestUtils.assertResponseStatus(tested.postTag(MOCK_CONTENT_ID_1, content), Status.BAD_REQUEST);
+	}
+
+	private static final String MOCK_PROVIDER_NAME = "jboss";
+
+	@Test
+	public void postTag() throws SearchIndexMissingException {
+		// case - unknown type
+		{
+			CustomTagRestService tested = getTested();
+			Mockito.when(tested.providerService.parseTypeNameFromSysId(MOCK_CONTENT_ID_1)).thenReturn(MOCK_PROVIDER_NAME);
+			Mockito.when(tested.providerService.findContentType(MOCK_PROVIDER_NAME)).thenReturn(null);
+
+			Map<String, Object> content = new HashMap<>();
+			content.put(CustomTagRestService.DATA_FIELD_TAGGING, "label");
+			TestUtils.assertResponseStatus(tested.postTag(MOCK_CONTENT_ID_1, content), Status.NOT_FOUND);
+
+			Mockito.verify(tested.providerService).findContentType(MOCK_PROVIDER_NAME);
+		}
+
+		// case - non existing document
+		{
+			CustomTagRestService tested = getTested();
+
+			Mockito.when(tested.providerService.parseTypeNameFromSysId(MOCK_CONTENT_ID_1)).thenReturn(MOCK_PROVIDER_NAME);
+
+			Map<String, Object> typeDef = mockTypeDef();
+			Mockito.when(tested.providerService.findContentType(MOCK_PROVIDER_NAME)).thenReturn(
+					ProviderServiceTest.createProviderContentTypeInfo(typeDef));
+
+			GetResponse grMock = Mockito.mock(GetResponse.class);
+			Mockito.when(grMock.isExists()).thenReturn(false);
+			Mockito.when(tested.searchClientService.performGet(MOCK_INDEX_NAME, MOCK_TYPE_NAME, MOCK_CONTENT_ID_1))
+					.thenReturn(grMock);
+
+			Map<String, Object> content = new HashMap<>();
+			content.put(CustomTagRestService.DATA_FIELD_TAGGING, "label");
+			TestUtils.assertResponseStatus(tested.postTag(MOCK_CONTENT_ID_1, content), Status.NOT_FOUND);
+
+			Mockito.verify(tested.searchClientService).performGet(MOCK_INDEX_NAME, MOCK_TYPE_NAME, MOCK_CONTENT_ID_1);
+		}
+
+		// case - customTag OK with document upgrade
+		{
+			CustomTagRestService tested = getTested();
+
+			Mockito.when(tested.providerService.parseTypeNameFromSysId(MOCK_CONTENT_ID_1)).thenReturn(MOCK_PROVIDER_NAME);
+			Mockito.when(tested.customTagPersistenceService.createTag(Mockito.any(Tag.class)))
+				.thenReturn(false);
+
+			Map<String, Object> typeDef = mockTypeDef();
+			Mockito.when(tested.providerService.findContentType(MOCK_PROVIDER_NAME)).thenReturn(
+					ProviderServiceTest.createProviderContentTypeInfo(typeDef));
+
+			GetResponse grMock = Mockito.mock(GetResponse.class);
+			Mockito.when(grMock.isExists()).thenReturn(true);
+			Mockito.when(tested.searchClientService.performGet(MOCK_INDEX_NAME, MOCK_TYPE_NAME, MOCK_CONTENT_ID_1))
+					.thenReturn(grMock);
+
+			Map<String, Object> requestContent = new HashMap<>();
+			requestContent.put(CustomTagRestService.DATA_FIELD_TAGGING, "label");
+			TestUtils.assertResponseStatus(tested.postTag(MOCK_CONTENT_ID_1, requestContent), Status.OK);
+
+			// verify service call
+			Mockito.verify(tested.searchClientService).performGet(MOCK_INDEX_NAME, MOCK_TYPE_NAME, MOCK_CONTENT_ID_1);
+
+			// verify jpa call
+			ArgumentCaptor argument = ArgumentCaptor.forClass(Tag.class);
+			Mockito.verify(tested.customTagPersistenceService).createTag((Tag) argument.capture());
+			Assert.assertEquals("label", ((Tag) argument.getValue()).getTagLabel());
+		}
+	}
+
+
+	@Test(expected = RequiredFieldException.class)
+	public void deleteTag_invalidParam_contentSysId_1() {
+		CustomTagRestService tested = getTested();
+		Map<String, Object> content = new HashMap<>();
+		content.put(CustomTagRestService.DATA_FIELD_TAGGING, "label");
+		tested.deleteTag(null, content);
+	}
+
+	@Test(expected = RequiredFieldException.class)
+	public void deleteTag_invalidParam_contentSysId_2() {
+		CustomTagRestService tested = getTested();
+		Map<String, Object> content = new HashMap<>();
+		content.put(CustomTagRestService.DATA_FIELD_TAGGING, "label");
+		tested.deleteTag(" ", content);
+	}
+
+	@Test
+	public void deleteTag_invalidParam_contentSysId_3() {
+		CustomTagRestService tested = getTested();
+		Map<String, Object> content = new HashMap<>();
+		content.put(CustomTagRestService.DATA_FIELD_TAGGING, "label");
+
+		// invalid format of contentSysId checked over providerService
+		Mockito.when(tested.providerService.parseTypeNameFromSysId("aa")).thenThrow(new IllegalArgumentException());
+		TestUtils.assertResponseStatus(tested.deleteTag("aa", content), Status.BAD_REQUEST);
+	}
+
+	@Test(expected = RequiredFieldException.class)
+	public void deleteTag_invalidParam_customTagValue_1() {
+		CustomTagRestService tested = getTested();
+		tested.deleteTag(MOCK_CONTENT_ID_1, null);
+	}
+
+	@Test(expected = RequiredFieldException.class)
+	public void deleteTag_invalidParam_customTagValue_2() {
+		CustomTagRestService tested = getTested();
+		prepareContentId(tested);
+		Map<String, Object> content = new HashMap<>();
+		tested.deleteTag(MOCK_CONTENT_ID_1, content);
+	}
+
+	@Test
+	public void deleteTag_invalidParam_customTagValue_3() {
+		CustomTagRestService tested = getTested();
+		prepareContentId(tested);
+		Map<String, Object> content = new HashMap<>();
+		content.put(CustomTagRestService.DATA_FIELD_TAGGING, new Object());
+		TestUtils.assertResponseStatus(tested.deleteTag(MOCK_CONTENT_ID_1, content), Status.BAD_REQUEST);
+
+		content.put(CustomTagRestService.DATA_FIELD_TAGGING, new Integer(6));
+		TestUtils.assertResponseStatus(tested.deleteTag(MOCK_CONTENT_ID_1, content), Status.BAD_REQUEST);
+	}
+
+	@Test
+	public void deleteTag() throws SearchIndexMissingException {
+		// case - unknown type
+		{
+			CustomTagRestService tested = getTested();
+			Mockito.when(tested.providerService.parseTypeNameFromSysId(MOCK_CONTENT_ID_1)).thenReturn(MOCK_PROVIDER_NAME);
+			Mockito.when(tested.providerService.findContentType(MOCK_PROVIDER_NAME)).thenReturn(null);
+
+			Map<String, Object> content = new HashMap<>();
+			content.put(CustomTagRestService.DATA_FIELD_TAGGING, "label");
+			TestUtils.assertResponseStatus(tested.deleteTag(MOCK_CONTENT_ID_1, content), Status.NOT_FOUND);
+
+			Mockito.verify(tested.providerService).findContentType(MOCK_PROVIDER_NAME);
+		}
+
+		// case - non existing document
+		{
+			CustomTagRestService tested = getTested();
+
+			Mockito.when(tested.providerService.parseTypeNameFromSysId(MOCK_CONTENT_ID_1)).thenReturn(MOCK_PROVIDER_NAME);
+
+			Map<String, Object> typeDef = mockTypeDef();
+			Mockito.when(tested.providerService.findContentType(MOCK_PROVIDER_NAME)).thenReturn(
+					ProviderServiceTest.createProviderContentTypeInfo(typeDef));
+
+			GetResponse grMock = Mockito.mock(GetResponse.class);
+			Mockito.when(grMock.isExists()).thenReturn(false);
+			Mockito.when(tested.searchClientService.performGet(MOCK_INDEX_NAME, MOCK_TYPE_NAME, MOCK_CONTENT_ID_1))
+					.thenReturn(grMock);
+
+			Map<String, Object> content = new HashMap<>();
+			content.put(CustomTagRestService.DATA_FIELD_TAGGING, "label");
+			TestUtils.assertResponseStatus(tested.deleteTag(MOCK_CONTENT_ID_1, content), Status.NOT_FOUND);
+
+			Mockito.verify(tested.searchClientService).performGet(MOCK_INDEX_NAME, MOCK_TYPE_NAME, MOCK_CONTENT_ID_1);
+		}
+
+		// case - customTag OK with document upgrade
+		{
+			CustomTagRestService tested = getTested();
+
+			Mockito.when(tested.providerService.parseTypeNameFromSysId(MOCK_CONTENT_ID_1)).thenReturn(MOCK_PROVIDER_NAME);
+			Mockito.when(tested.customTagPersistenceService.createTag(Mockito.any(Tag.class)))
+				.thenReturn(true);
+
+			Map<String, Object> typeDef = mockTypeDef();
+			Mockito.when(tested.providerService.findContentType(MOCK_PROVIDER_NAME)).thenReturn(
+					ProviderServiceTest.createProviderContentTypeInfo(typeDef));
+
+			GetResponse grMock = Mockito.mock(GetResponse.class);
+			Mockito.when(grMock.isExists()).thenReturn(true);
+			Mockito.when(tested.searchClientService.performGet(MOCK_INDEX_NAME, MOCK_TYPE_NAME, MOCK_CONTENT_ID_1))
+					.thenReturn(grMock);
+
+			Map<String, Object> requestContent = new HashMap<>();
+			requestContent.put(CustomTagRestService.DATA_FIELD_TAGGING, "label");
+			TestUtils.assertResponseStatus(tested.deleteTag(MOCK_CONTENT_ID_1, requestContent), Status.OK);
+
+			// verify service call
+			Mockito.verify(tested.searchClientService).performGet(MOCK_INDEX_NAME, MOCK_TYPE_NAME, MOCK_CONTENT_ID_1);
+
+			// verify jpa call
+			Mockito.verify(tested.customTagPersistenceService).deleteTag(MOCK_CONTENT_ID_1, "label");
+		}
+	}
+
+	@Test(expected = RequiredFieldException.class)
+	public void deleteTagsForContent_invalidParam_contentSysId_1() {
+		CustomTagRestService tested = getTested();
+		tested.deleteTagsForContent(null);
+	}
+
+	@Test(expected = RequiredFieldException.class)
+	public void deleteTagsForContent_invalidParam_contentSysId_2() {
+		CustomTagRestService tested = getTested();
+		tested.deleteTagsForContent(" ");
+	}
+
+	@Test
+	public void deleteTagsForContent_invalidParam_contentSysId_3() {
+		CustomTagRestService tested = getTested();
+
+		// invalid format of contentSysId checked over providerService
+		Mockito.when(tested.providerService.parseTypeNameFromSysId("aa")).thenThrow(new IllegalArgumentException());
+		TestUtils.assertResponseStatus(tested.deleteTagsForContent("aa"), Status.BAD_REQUEST);
+	}
+
+	@Test
+	public void deleteTagsForContent() throws SearchIndexMissingException {
+		// case - unknown type
+		{
+			CustomTagRestService tested = getTested();
+			Mockito.when(tested.providerService.parseTypeNameFromSysId(MOCK_CONTENT_ID_1)).thenReturn(MOCK_PROVIDER_NAME);
+			Mockito.when(tested.providerService.findContentType(MOCK_PROVIDER_NAME)).thenReturn(null);
+
+			TestUtils.assertResponseStatus(tested.deleteTagsForContent(MOCK_CONTENT_ID_1), Status.NOT_FOUND);
+
+			Mockito.verify(tested.providerService).findContentType(MOCK_PROVIDER_NAME);
+		}
+
+		// case - non existing document
+		{
+			CustomTagRestService tested = getTested();
+
+			Mockito.when(tested.providerService.parseTypeNameFromSysId(MOCK_CONTENT_ID_1)).thenReturn(MOCK_PROVIDER_NAME);
+
+			Map<String, Object> typeDef = mockTypeDef();
+			Mockito.when(tested.providerService.findContentType(MOCK_PROVIDER_NAME)).thenReturn(
+					ProviderServiceTest.createProviderContentTypeInfo(typeDef));
+
+			GetResponse grMock = Mockito.mock(GetResponse.class);
+			Mockito.when(grMock.isExists()).thenReturn(false);
+			Mockito.when(tested.searchClientService.performGet(MOCK_INDEX_NAME, MOCK_TYPE_NAME, MOCK_CONTENT_ID_1))
+					.thenReturn(grMock);
+
+			TestUtils.assertResponseStatus(tested.deleteTagsForContent(MOCK_CONTENT_ID_1), Status.NOT_FOUND);
+
+			Mockito.verify(tested.searchClientService).performGet(MOCK_INDEX_NAME, MOCK_TYPE_NAME, MOCK_CONTENT_ID_1);
+		}
+
+		// case - customTag OK with document upgrade
+		{
+			CustomTagRestService tested = getTested();
+
+			Mockito.when(tested.providerService.parseTypeNameFromSysId(MOCK_CONTENT_ID_1)).thenReturn(MOCK_PROVIDER_NAME);
+
+			Map<String, Object> typeDef = mockTypeDef();
+			Mockito.when(tested.providerService.findContentType(MOCK_PROVIDER_NAME)).thenReturn(
+					ProviderServiceTest.createProviderContentTypeInfo(typeDef));
+
+			GetResponse grMock = Mockito.mock(GetResponse.class);
+			Mockito.when(grMock.isExists()).thenReturn(true);
+			Mockito.when(tested.searchClientService.performGet(MOCK_INDEX_NAME, MOCK_TYPE_NAME, MOCK_CONTENT_ID_1))
+					.thenReturn(grMock);
+
+			TestUtils.assertResponseStatus(tested.deleteTagsForContent(MOCK_CONTENT_ID_1), Status.OK);
+
+			// verify service call
+			Mockito.verify(tested.searchClientService).performGet(MOCK_INDEX_NAME, MOCK_TYPE_NAME, MOCK_CONTENT_ID_1);
+
+			// verify jpa call
+			Mockito.verify(tested.customTagPersistenceService).deleteTagsForContent(MOCK_CONTENT_ID_1);
+		}
+	}
+
+	protected Map<String, Object> mockTypeDef() {
+		Map<String, Object> typeDef = new HashMap<String, Object>();
+		Map<String, Object> indexElement = new HashMap<String, Object>();
+		typeDef.put(ProviderService.INDEX, indexElement);
+		indexElement.put(ProviderService.NAME, MOCK_INDEX_NAME);
+		indexElement.put(ProviderService.TYPE, MOCK_TYPE_NAME);
+		return typeDef;
+	}
+
+	protected CustomTagRestService getTested() {
+		CustomTagRestService tested = new CustomTagRestService();
+		tested.log = Logger.getLogger("testlogger");
+		tested.customTagPersistenceService = Mockito.mock(CustomTagPersistenceService.class);
+		tested.customTagService = Mockito.mock(CustomTagService.class);
+		tested.providerService = Mockito.mock(ProviderService.class);
+		tested.searchClientService = Mockito.mock(SearchClientService.class);
+		tested.authenticationUtilService = Mockito.mock(AuthenticationUtilService.class);
+		Mockito.when(
+				tested.authenticationUtilService.getAuthenticatedContributor(
+						Mockito.anyBoolean())).thenReturn(MOCK_CONTRIB_ID);
+		// Pretend authenticated
+		tested.authenticationUtilService = Mockito.mock(AuthenticationUtilService.class);
+		Mockito.when(
+				tested.authenticationUtilService.isUserInAnyOfRoles(Mockito.anyBoolean(), Mockito.anyString(), Mockito.anyString())).thenReturn(true);
+
+		return tested;
+	}
+
+	private void prepareContentId(CustomTagRestService tested) {
+
+			Mockito.when(tested.providerService.parseTypeNameFromSysId(MOCK_CONTENT_ID_1)).thenReturn(MOCK_PROVIDER_NAME);
+
+			Map<String, Object> typeDef = mockTypeDef();
+			Mockito.when(tested.providerService.findContentType(MOCK_PROVIDER_NAME)).thenReturn(
+					ProviderServiceTest.createProviderContentTypeInfo(typeDef));
+	}
+
+}

--- a/api/src/test/java/org/searchisko/api/service/CustomTagServiceTest.java
+++ b/api/src/test/java/org/searchisko/api/service/CustomTagServiceTest.java
@@ -1,0 +1,170 @@
+/*
+ * JBoss, Home of Professional Open Source
+ * Copyright 2014 Red Hat Inc. and/or its affiliates and other contributors
+ * as indicated by the @authors tag. All rights reserved.
+ */
+package org.searchisko.api.service;
+
+import java.sql.Timestamp;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.logging.Logger;
+import org.junit.Assert;
+
+import org.junit.Test;
+import org.mockito.Mockito;
+import org.searchisko.api.events.ContentDeletedEvent;
+import org.searchisko.api.events.ContributorMergedEvent;
+import org.searchisko.persistence.service.CustomTagPersistenceService;
+
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.reset;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyZeroInteractions;
+import org.searchisko.api.ContentObjectFields;
+import org.searchisko.api.events.ContentBeforeIndexedEvent;
+import org.searchisko.api.events.ContributorCodeChangedEvent;
+import org.searchisko.persistence.jpa.model.Tag;
+
+/**
+ * Unit test for {@link CustomTagService}.
+ *
+ * @author Jiri Mauritz (jirmauritz at gmail dot com)
+ */
+public class CustomTagServiceTest {
+
+	@Test
+	public void contentDeletedEventHandler() {
+		CustomTagService tested = getTested();
+
+		// case - invalid event
+		tested.contentDeletedEventHandler(null);
+		verifyZeroInteractions(tested.customTagPersistenceService);
+
+		reset(tested.customTagPersistenceService);
+		tested.contentDeletedEventHandler(new ContentDeletedEvent(null));
+		verifyZeroInteractions(tested.customTagPersistenceService);
+
+		// case - valid event
+		reset(tested.customTagPersistenceService);
+		tested.contentDeletedEventHandler(new ContentDeletedEvent("id"));
+		verify(tested.customTagPersistenceService).deleteTagsForContent("id");
+
+	}
+
+	@Test
+	public void contributorMergedEventHandler() {
+		CustomTagService tested = getTested();
+
+		// case - invalid event
+		tested.contributorMergedEventHandler(null);
+		verifyZeroInteractions(tested.customTagPersistenceService);
+
+		reset(tested.customTagPersistenceService);
+		tested.contributorMergedEventHandler(new ContributorMergedEvent(null, null));
+		verifyZeroInteractions(tested.customTagPersistenceService);
+
+		reset(tested.customTagPersistenceService);
+		tested.contributorMergedEventHandler(new ContributorMergedEvent("idFrom", null));
+		verifyZeroInteractions(tested.customTagPersistenceService);
+
+		reset(tested.customTagPersistenceService);
+		tested.contributorMergedEventHandler(new ContributorMergedEvent(null, "idTo"));
+		verifyZeroInteractions(tested.customTagPersistenceService);
+
+		// case - valid event
+		reset(tested.customTagPersistenceService);
+		tested.contributorMergedEventHandler(new ContributorMergedEvent("idFrom", "idTo"));
+		verify(tested.customTagPersistenceService).changeOwnershipOfTags("idFrom", "idTo");
+	}
+
+	@Test
+	public void contributorCodeChangedEventHandler() {
+		CustomTagService tested = getTested();
+
+		// case - invalid event
+		tested.contributorCodeChangedEventHandler(null);
+		verifyZeroInteractions(tested.customTagPersistenceService);
+
+		reset(tested.customTagPersistenceService);
+		tested.contributorCodeChangedEventHandler(new ContributorCodeChangedEvent(null, null));
+		verifyZeroInteractions(tested.customTagPersistenceService);
+
+		reset(tested.customTagPersistenceService);
+		tested.contributorCodeChangedEventHandler(new ContributorCodeChangedEvent("idFrom", null));
+		verifyZeroInteractions(tested.customTagPersistenceService);
+
+		reset(tested.customTagPersistenceService);
+		tested.contributorCodeChangedEventHandler(new ContributorCodeChangedEvent(null, "idTo"));
+		verifyZeroInteractions(tested.customTagPersistenceService);
+
+		// case - valid event
+		reset(tested.customTagPersistenceService);
+		tested.contributorCodeChangedEventHandler(new ContributorCodeChangedEvent("idFrom", "idTo"));
+		verify(tested.customTagPersistenceService).changeOwnershipOfTags("idFrom", "idTo");
+	}
+
+	@Test
+	public void contentBeforeIndexedHandler() {
+		CustomTagService tested = getTested();
+
+		// case - invalid event
+		tested.contentBeforeIndexedHandler(null);
+		verifyZeroInteractions(tested.customTagPersistenceService);
+
+		reset(tested.customTagPersistenceService);
+		tested.contentBeforeIndexedHandler(new ContentBeforeIndexedEvent(null, null));
+		verifyZeroInteractions(tested.customTagPersistenceService);
+
+		reset(tested.customTagPersistenceService);
+		tested.contentBeforeIndexedHandler(new ContentBeforeIndexedEvent("id", null));
+		verifyZeroInteractions(tested.customTagPersistenceService);
+
+		reset(tested.customTagPersistenceService);
+		tested.contentBeforeIndexedHandler(new ContentBeforeIndexedEvent(null, new HashMap<String, Object>()));
+		verifyZeroInteractions(tested.customTagPersistenceService);
+
+		// test of updateSysTagsField method
+
+		// case - copying of provider tag
+		{
+			reset(tested.customTagPersistenceService);
+			Map<String, Object> content = new HashMap<String, Object>();
+			List<String> listOfLabels = new ArrayList<String>();
+			listOfLabels.add("label1");
+			listOfLabels.add("label2");
+			content.put(ContentObjectFields.TAGS, listOfLabels);
+			Mockito.when(tested.customTagPersistenceService.getTagsByContent("id")).thenReturn(new ArrayList<Tag>());
+			tested.contentBeforeIndexedHandler(new ContentBeforeIndexedEvent("id", content));
+			Assert.assertEquals(listOfLabels, content.get(ContentObjectFields.SYS_TAGS));
+		}
+
+		// case - copying of custom tag
+		{
+			reset(tested.customTagPersistenceService);
+			Map<String, Object> content = new HashMap<String, Object>();
+			content.put(ContentObjectFields.TAGS, null);
+			content.put(ContentObjectFields.SYS_ID, "contentId");
+			List<Tag> listOfTags = new ArrayList<Tag>();
+			listOfTags.add(new Tag("contentId", "contributorId", "label"));
+			Mockito.when(tested.customTagPersistenceService.getTagsByContent("contentId")).thenReturn(listOfTags);
+			tested.contentBeforeIndexedHandler(new ContentBeforeIndexedEvent("contentId", content));
+			List<String> listOfLabel = new ArrayList<String>();
+			listOfLabel.add("label");
+			Assert.assertEquals(listOfLabel, content.get(ContentObjectFields.SYS_TAGS));
+		}
+
+		//TODO merge obou skupin i s osetrenim duplicit
+
+	}
+
+	private CustomTagService getTested() {
+		CustomTagService ret = new CustomTagService();
+		ret.customTagPersistenceService = mock(CustomTagPersistenceService.class);
+		ret.log = Logger.getLogger("testlogger");
+		return ret;
+	}
+
+}

--- a/api/src/test/java/org/searchisko/persistence/service/JpaCustomTagPersistenceServiceTest.java
+++ b/api/src/test/java/org/searchisko/persistence/service/JpaCustomTagPersistenceServiceTest.java
@@ -1,0 +1,247 @@
+/*
+ * JBoss, Home of Professional Open Source
+ * Copyright 2013 Red Hat Inc. and/or its affiliates and other contributors
+ * as indicated by the @authors tag. All rights reserved.
+ */
+package org.searchisko.persistence.service;
+
+import java.sql.Timestamp;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.logging.Logger;
+
+import org.junit.Assert;
+import org.junit.Test;
+import org.searchisko.persistence.jpa.model.Tag;
+
+/**
+ * Unit test for {@link JpaCustomTagPersistenceService}
+ *
+ * @author Jiri Mauritz (jirmauritz at gmail dot com)
+ */
+public class JpaCustomTagPersistenceServiceTest extends JpaTestBase {
+
+	private static final String CONTENT_TYPE_1 = "type1";
+	private static final String CONTENT_TYPE_2 = "type2";
+	private static final String CONTENT_TYPE_1_ID_2 = "type1-contId2";
+	private static final String CONTENT_TYPE_1_ID_1 = "type1-contId1";
+	private static final String CONTENT_TYPE_2_ID_2 = "type2-contId2";
+	private static final String CONTENT_TYPE_2_ID_1 = "type2-contId1";
+	private static final String CONTRIB_ID_2 = "contribId2";
+	private static final String CONTRIB_ID_1 = "contribId1";
+
+	{
+		logger = Logger.getLogger(JpaCustomTagPersistenceServiceTest.class.getName());
+	}
+
+	@Test
+	public void getTags_createTag() {
+		JpaCustomTagPersistenceService tested = getTested();
+
+		// case - get from empty store
+		em.getTransaction().begin();
+		List<Tag> ret = tested.getTagsByContent(CONTENT_TYPE_1_ID_1);
+		Assert.assertTrue(ret.isEmpty());
+
+		Tag tag1 = new Tag(CONTENT_TYPE_1_ID_1, CONTRIB_ID_1, "label1");
+		Tag tag2 = new Tag(CONTENT_TYPE_1_ID_1, CONTRIB_ID_2, "label2");
+		Tag tag3 = new Tag(CONTENT_TYPE_1_ID_2, CONTRIB_ID_2, "label3");
+		Tag tag4 = new Tag(CONTENT_TYPE_2_ID_1, CONTRIB_ID_2, "label4");
+
+		// create tags
+		tested.createTag(tag1);
+		tested.createTag(tag2);
+		tested.createTag(tag3);
+		tested.createTag(tag4);
+
+		em.getTransaction().commit();
+		em.getTransaction().begin();
+
+		// get tag for content 1
+		ret = tested.getTagsByContent(CONTENT_TYPE_1_ID_1);
+		Assert.assertEquals(2, ret.size());
+		ret = tested.getTagsByContent(CONTENT_TYPE_1_ID_2);
+		Assert.assertEquals(1, ret.size());
+		Tag testedTag = ret.get(0);
+		Assert.assertEquals(tag3.getContentId(), testedTag.getContentId());
+		Assert.assertEquals(tag3.getContributorId(), testedTag.getContributorId());
+		Assert.assertEquals(tag3.getTagLabel(), testedTag.getTagLabel());
+		Assert.assertEquals(tag3.getCreatedAt(), testedTag.getCreatedAt());
+
+		em.getTransaction().commit();
+		em.getTransaction().begin();
+
+		// get tags for content type 1
+		ret = tested.getTagsByContentType(CONTENT_TYPE_1);
+		Assert.assertEquals(3, ret.size());
+
+		List<String> labels = new ArrayList<>();
+		for (Tag tag : ret) {
+			labels.add(tag.getTagLabel());
+		}
+
+		Assert.assertTrue(labels.contains("label1"));
+		Assert.assertTrue(labels.contains("label2"));
+		Assert.assertTrue(labels.contains("label3"));
+		em.getTransaction().commit();
+
+		// get tags for content type 2
+		em.getTransaction().begin();
+		ret = tested.getTagsByContentType(CONTENT_TYPE_2);
+		Assert.assertEquals(1, ret.size());
+
+		Assert.assertTrue(ret.get(0).getTagLabel().equals("label4"));
+		em.getTransaction().commit();
+
+		// get tags for nonexisting content type
+		em.getTransaction().begin();
+		ret = tested.getTagsByContentType("nonexistingType");
+		Assert.assertEquals(0, ret.size());
+		em.getTransaction().commit();
+	}
+
+	@Test
+	public void changeOwnershipOfTags() {
+		JpaCustomTagPersistenceService tested = getTested();
+
+		em.getTransaction().begin();
+		// create tags
+		Tag tag1 = new Tag(CONTENT_TYPE_1_ID_1, CONTRIB_ID_1, "label1");
+		Tag tag2 = new Tag(CONTENT_TYPE_1_ID_1, CONTRIB_ID_2, "label2");
+		Tag tag3 = new Tag(CONTENT_TYPE_1_ID_1, CONTRIB_ID_2, "label3");
+
+		tested.createTag(tag1);
+		tested.createTag(tag2);
+		tested.createTag(tag3);
+
+		List<Tag> ret = tested.getTagsByContentType(CONTENT_TYPE_1_ID_1);
+		Assert.assertEquals(3, ret.size());
+
+		int count = 0;
+		for (Tag tag : ret) {
+			if (tag.getContributorId().equals(CONTRIB_ID_2)) {
+				count++;
+			}
+		}
+
+		Assert.assertEquals(2, count);
+
+		System.out.println("pred: " + tested.getTagsByContentType(CONTENT_TYPE_1_ID_1));
+		em.getTransaction().commit();
+
+		em.getTransaction().begin();
+		tested.changeOwnershipOfTags(CONTRIB_ID_1, CONTRIB_ID_2);
+		em.getTransaction().commit();
+
+		em.getTransaction().begin();
+		System.out.println("po: " + tested.getTagsByContentType(CONTENT_TYPE_1_ID_1));
+
+		ret = tested.getTagsByContentType(CONTENT_TYPE_1_ID_1);
+		Assert.assertEquals(3, ret.size());
+
+		count = 0;
+		for (Tag tag : ret) {
+			if (tag.getContributorId().equals(CONTRIB_ID_2)) {
+				count++;
+			}
+		}
+
+		Assert.assertEquals(3, count);
+		em.getTransaction().commit();
+	}
+
+	@Test
+	public void deleteTag() {
+		JpaCustomTagPersistenceService tested = getTested();
+
+		Tag tag1 = new Tag(CONTENT_TYPE_1_ID_1, CONTRIB_ID_1, "label1");
+		Tag tag2 = new Tag(CONTENT_TYPE_1_ID_1, CONTRIB_ID_2, "label2");
+		Tag tag3 = new Tag(CONTENT_TYPE_1_ID_2, CONTRIB_ID_2, "label3");
+
+		em.getTransaction().begin();
+		tested.createTag(tag1);
+		tested.createTag(tag2);
+		tested.createTag(tag3);
+		em.getTransaction().commit();
+
+		em.getTransaction().begin();
+		// case - nonexisting label
+		tested.deleteTag(CONTENT_TYPE_1_ID_1, "nonexisting label");
+		List<Tag> ret = tested.getTagsByContentType(CONTENT_TYPE_1);
+		Assert.assertEquals(3, ret.size());
+		em.getTransaction().commit();
+
+		em.getTransaction().begin();
+		// case - existing label with other content id
+		tested.deleteTag(CONTENT_TYPE_1_ID_2, "label2");
+		ret = tested.getTagsByContentType(CONTENT_TYPE_1);
+		Assert.assertEquals(3, ret.size());
+		em.getTransaction().commit();
+
+		em.getTransaction().begin();
+		// case - delete label1
+		tested.deleteTag(CONTENT_TYPE_1_ID_1, "label1");
+		ret = tested.getTagsByContentType(CONTENT_TYPE_1);
+		Assert.assertEquals(2, ret.size());
+		Tag testedTag1 = ret.get(0);
+		Tag testedTag2 = ret.get(1);
+
+		if (testedTag1.getTagLabel().equals("label2")) {
+			Assert.assertEquals(tag2.getContentId(), testedTag1.getContentId());
+			Assert.assertEquals(tag2.getContributorId(), testedTag1.getContributorId());
+
+			Assert.assertEquals(tag3.getContentId(), testedTag2.getContentId());
+			Assert.assertEquals(tag3.getContributorId(), testedTag2.getContributorId());
+			Assert.assertEquals("label3", testedTag2.getTagLabel());
+		} else {
+			Assert.assertEquals(tag2.getContentId(), testedTag2.getContentId());
+			Assert.assertEquals(tag2.getContributorId(), testedTag2.getContributorId());
+
+			Assert.assertEquals(tag3.getContentId(), testedTag1.getContentId());
+			Assert.assertEquals(tag3.getContributorId(), testedTag1.getContributorId());
+			Assert.assertEquals("label3", testedTag1.getTagLabel());
+		}
+
+		em.getTransaction().commit();
+	}
+
+	@Test
+	public void deleteTagsForContent() {
+		JpaCustomTagPersistenceService tested = getTested();
+
+		Tag tag1 = new Tag(CONTENT_TYPE_1_ID_1, CONTRIB_ID_1, "label1");
+		Tag tag2 = new Tag(CONTENT_TYPE_1_ID_1, CONTRIB_ID_2, "label2");
+		Tag tag3 = new Tag(CONTENT_TYPE_1_ID_2, CONTRIB_ID_2, "label3");
+
+		em.getTransaction().begin();
+		tested.createTag(tag1);
+		tested.createTag(tag2);
+		tested.createTag(tag3);
+		em.getTransaction().commit();
+
+		em.getTransaction().begin();
+		// case - no content specified
+		tested.deleteTagsForContent((String[]) null);
+		List<Tag> ret = tested.getTagsByContentType(CONTENT_TYPE_1);
+		Assert.assertEquals(3, ret.size());
+		em.getTransaction().commit();
+
+		em.getTransaction().begin();
+		// case - delete for content 1
+		tested.deleteTagsForContent(CONTENT_TYPE_1_ID_1);
+		ret = tested.getTagsByContentType(CONTENT_TYPE_1);
+		Assert.assertEquals(1, ret.size());
+		Tag testedTag = ret.get(0);
+		Assert.assertEquals(CONTENT_TYPE_1_ID_2, testedTag.getContentId());
+		Assert.assertEquals(CONTRIB_ID_2, testedTag.getContributorId());
+		Assert.assertEquals("label3", testedTag.getTagLabel());
+
+		em.getTransaction().commit();
+	}
+
+	protected JpaCustomTagPersistenceService getTested() {
+		JpaCustomTagPersistenceService tested = new JpaCustomTagPersistenceService();
+		tested.em = em;
+		return tested;
+	}
+}

--- a/api/src/test/resources/META-INF/persistence.xml
+++ b/api/src/test/resources/META-INF/persistence.xml
@@ -10,6 +10,7 @@
     <class>org.searchisko.persistence.jpa.model.Project</class>
     <class>org.searchisko.persistence.jpa.model.Query</class>
     <class>org.searchisko.persistence.jpa.model.Rating</class>
+    <class>org.searchisko.persistence.jpa.model.Tag</class>
     <class>org.searchisko.api.tasker.TaskStatusInfo</class>
 		<properties>
 			<!-- Bean validation is used for validation and DDL as well -->

--- a/apiary.apib
+++ b/apiary.apib
@@ -804,6 +804,144 @@ POST /rest/rating/{_id}
   "sys_rating_num" : 24
 }
 
+--
+Custom Tag API
+
+This part of API allows to store and retrieve custom tags for any document stored inside Searchisko. 
+Custom tags allow users to classify the content in the Searchisko and improve searching.
+
+Custom tags are stored in the field `sys_tags` together with tags provided by the content provider.
+GET methods show provider tags, however this API cannot update them in any way.
+
+This API requires User authentication. All calls of this API return `403` Forbidden http response code if user is not authenticated!
+More specifically, you need to have TAGS_MANAGER role to access all tags or
+TAGS_MANAGER_[contentTypeId] role to access tags for content type `content type`.
+
+When called directly from Web Browser, this API cooperates with 'User Authentication Status API' to establish user authenticity,
+so you have to call 'User Authentication Status API' before you call this API in this case.
+--
+
+Get all tags for one document.
+
+##### Request parameters
+
+* `_id` unique identifier of the document in Searchisko to get all tags for (`_id` document field in search API results).
+
+##### Response content
+
+The response contains a JSON object where `tag` holds array of all the tags.
+
+```
+{
+  "tag" : [
+	"linux",
+	"red hat"
+  ]
+}
+```
+
+GET /rest/tagging/{_id}
+< 200
+< Content-Type: application/json
+{
+  "tag" : [
+	"linux",
+	"red hat"
+  ]
+}
+
+
+Get all tags for documents of one type.
+
+##### Request parameters
+
+* `id` unique identifier of the content type in Searchisko to get all tags for (`_type` document field in search API results).
+
+##### Response content
+
+The response contains a JSON object where `tag` holds array of all the tags.
+
+```
+{
+  "tag" : [
+	"linux",
+	"red hat"
+  ]
+}
+```
+
+GET /rest/tagging/type{?id}
+< 200
+< Content-Type: application/json
+{
+  "tag" : [
+	"linux",
+	"red hat"
+  ]
+}
+
+
+Assign tag to document.
+
+##### Request parameter
+
+* `id` unique identifier of the document in Searchisko to store custom tag for (`_id` document field in search API results).
+
+##### Request content
+JSON object with tag label to store in `tag` mandatory field.
+
+```
+{
+  "tag" : "label"
+}
+```
+
+##### Response status
+201 (Created) when the tag was created
+
+200 (OK) when there was same tag for the document (no changes)
+
+POST /rest/tagging/{_id}
+> Content-Type: application/json
+{
+  "tag" : "label"
+}
+< 201
+
+
+Delete tag.
+
+##### Request parameter
+
+* `id` unique identifier of the document in Searchisko to delete custom tag for (`_id` document field in search API results).
+
+##### Request content
+JSON object with tag label to delete in `tag` mandatory field.
+
+```
+{
+  "tag" : "label"
+}
+```
+
+DELETE /rest/tagging/{_id}
+> Content-Type: application/json
+{
+  "tag" : "label"
+}
+< 200
+
+
+Delete all tags for content.
+
+##### Request parameter
+
+* `id` unique identifier of the document in Searchisko to delete custom tag for (`_id` document field in search API results).
+
+DELETE /rest/tagging/{_id}/_all
+> Content-Type: application/json
+< 200
+
 
 --
 Normalization API

--- a/documentation/rest-api/README.md
+++ b/documentation/rest-api/README.md
@@ -72,6 +72,8 @@ Once provider/user is authenticated then it can be granted by following roles wh
 4. `contributors_manager` - full access to `/rest/contributor` Management API
 5. `projects_manager` - full access to `/rest/project` Management API
 6. `tasks_manager` - full access to `/rest/tasks` Management API
+7. `tags_manager` - full acces to /rest/tagging API for all content types
+8. `tags_manager_x` - access to /rest/tagging API for content type x
 
 *Provider* can have only default `provider` role or can have `admin` role if defined in 
 [provider configuration](management/content_provider.md).

--- a/ftest/src/test/java/org/searchisko/ftest/rest/CustomTagRestServiceTest.java
+++ b/ftest/src/test/java/org/searchisko/ftest/rest/CustomTagRestServiceTest.java
@@ -1,0 +1,175 @@
+/*
+ * JBoss, Home of Professional Open Source
+ * Copyright 2012 Red Hat Inc. and/or its affiliates and other contributors
+ * as indicated by the @authors tag. All rights reserved.
+ */
+package org.searchisko.ftest.rest;
+
+import java.io.IOException;
+import java.net.MalformedURLException;
+import java.net.URL;
+import java.util.HashMap;
+import java.util.Map;
+
+import com.jayway.restassured.http.ContentType;
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.arquillian.junit.InSequence;
+import org.jboss.arquillian.test.api.ArquillianResource;
+import org.jboss.shrinkwrap.api.spec.WebArchive;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.searchisko.ftest.DeploymentHelpers;
+import org.searchisko.ftest.ProviderModel;
+
+import static com.jayway.restassured.RestAssured.given;
+import static org.hamcrest.Matchers.*;
+import org.searchisko.persistence.jpa.model.Tag;
+
+/**
+ * Integration test for /tagging REST API.
+ * <p/>
+ * http://docs.jbossorg.apiary.io/#customtags *TODO*
+ *
+ * @author Jiri Mauritz
+ * @see org.searchisko.api.rest.CustomTagRestService
+ */
+@RunWith(Arquillian.class)
+public class CustomTagRestServiceTest {
+
+	public static final String TAGGING_REST_API_BASE = DeploymentHelpers.DEFAULT_REST_VERSION + "tagging/";
+
+	public static final String TAGGING_REST_API = TAGGING_REST_API_BASE + "{id}";
+	public static final String TAGGING_REST_API_TYPE = TAGGING_REST_API_BASE + "type/{id}";
+
+	@Deployment(testable = false)
+	public static WebArchive createDeployment() throws IOException {
+		return DeploymentHelpers.createDeployment();
+	}
+
+	@ArquillianResource
+	URL context;
+
+
+	@Test
+	@InSequence(0)
+	public void assertNotAuthenticated() throws MalformedURLException {
+		int expStatus = 403;
+
+		// GET /tagging
+		given().contentType(ContentType.JSON)
+				.expect()
+				.log().ifValidationFails()
+				.statusCode(expStatus)
+				.header("WWW-Authenticate", nullValue())
+				.body(is("Required authorization {0}."))
+				.when().get(new URL(context, TAGGING_REST_API_BASE).toExternalForm());
+
+		// GET /rating/bad-id
+		given().contentType(ContentType.JSON)
+				.pathParam("id", "bad-id")
+				.expect().statusCode(expStatus)
+				.header("WWW-Authenticate", nullValue())
+				.log().ifValidationFails()
+				.when().get(new URL(context, TAGGING_REST_API).toExternalForm());
+
+		// POST /rating/bad-id
+		given().contentType(ContentType.JSON)
+				.pathParam("id", "bad-id")
+				.expect().statusCode(expStatus)
+				.header("WWW-Authenticate", nullValue())
+				.log().ifValidationFails()
+				.when().post(new URL(context, TAGGING_REST_API).toExternalForm());
+
+	}
+
+	public static final String TYPE1 = "provider1_blog";
+
+	static ProviderModel provider1 = new ProviderModel("provider1", "password");
+
+	static final String contentId = "test-id";
+
+	@Test
+	@InSequence(1)
+	public void assertCreateProvider1BlogPost() throws MalformedURLException {
+		provider1.addContentType(TYPE1, "blogpost", true);
+
+		ProviderRestServiceTest.createNewProvider(context, provider1);
+	}
+
+	@Test
+	@InSequence(2)
+	public void assertPushContentWithId() throws MalformedURLException {
+		Map<String, Object> content = new HashMap<>();
+		content.put("data", "test");
+		ContentRestServiceTest.createOrUpdateContent(context, provider1, TYPE1, contentId, content);
+	}
+
+	@Test
+	@InSequence(3)
+	public void assertRefreshES() throws MalformedURLException {
+		DeploymentHelpers.refreshES();
+	}
+
+	@Test
+	@InSequence(5)
+	public void assertCreateContributor() throws MalformedURLException {
+		final Map<String, Object> typeSpecificCode = new HashMap<>();
+		typeSpecificCode.put("jbossorg_username", contribUsername);
+
+		String contributorCode = "TEST <test@test.com>";
+
+		final Map<String, Object> params = new HashMap<>();
+		params.put("code", contributorCode);
+		params.put("email", "test@test.com");
+		params.put("type_specific_code", typeSpecificCode);
+		ContributorRestServiceTest.createContributor(context, params);
+	}
+
+
+	String contribUsername = "contributor1";
+
+	String contribPassword = "password1";
+
+	final String contentIdToTag = TYPE1 + "-" + contentId;
+
+	@Test
+	@InSequence(11)
+	public void assertRate() throws MalformedURLException {
+		Map<String, Object> tagging = new HashMap<>();
+		tagging.put("tag", "label");
+
+		given().contentType(ContentType.JSON)
+				.auth().preemptive().basic(contribUsername, contribPassword)
+				.pathParam("id", contentIdToTag)
+				.body(tagging)
+				.expect().statusCode(201)
+				.log().ifValidationFails()
+				.when().post(new URL(context, TAGGING_REST_API).toExternalForm());
+
+		given().contentType(ContentType.JSON)
+				.pathParam("id", contentIdToTag)
+				.auth().preemptive().basic(contribUsername, contribPassword)
+				.expect()
+				.log().ifValidationFails()
+				.statusCode(200)
+				.contentType(ContentType.JSON)
+				.body("tag", is("{\"tag\":[\"label\"]}"))
+				.when().get(new URL(context, TAGGING_REST_API).toExternalForm());
+	}
+
+	@Test
+	@InSequence(20)
+	public void assertGetAllForType() throws MalformedURLException {
+		given().contentType(ContentType.JSON)
+				.queryParam("id", TYPE1)
+				.auth().preemptive().basic(contribUsername, contribPassword)
+				.expect()
+				.log().ifValidationFails()
+				.statusCode(200)
+				.contentType(ContentType.JSON)
+				.body("tag", is("{\"tag\":[\"label\"]}"))
+				.when().get(new URL(context, TAGGING_REST_API_TYPE).toExternalForm());
+	}
+
+}


### PR DESCRIPTION
New API to handle custom tags.
- object Tag as persistence entity created
- jpa methods working with tags: 
 - getTagsByContent
 - getTagsByContentType
 - postTag
 - deleteTagsForContent
 - deleteTag
- REST API handling all jpa methods
- unit tests
- integrated test
- apiary documentation
- new Role: TAGS_MANAGER